### PR TITLE
fix(wallet-ios): accept mixed DID aliases

### DIFF
--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
       - name: Run tests
-        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6'
+        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
         working-directory: VCL
 
   set-environment:

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
       - name: Run tests
-        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6'
+        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
         working-directory: VCL

--- a/VCL/VCL/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.swift
+++ b/VCL/VCL/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.swift
@@ -18,8 +18,13 @@ final class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByDeep
         completionBlock: @escaping (VCLResult<Bool>) -> Void
     ) {
         if let deepLinkDid = deepLink.did {
-            if (didDocument.id == presentationRequest.iss && didDocument.id == deepLinkDid ||
-                didDocument.alsoKnownAs.contains(presentationRequest.iss) && didDocument.alsoKnownAs.contains(deepLinkDid)) {
+            if isDidBoundToDidDocument(
+                presentationRequest.iss,
+                didDocument: didDocument
+            ) && isDidBoundToDidDocument(
+                deepLinkDid,
+                didDocument: didDocument
+            ) {
                 completionBlock(.success(true))
             } else {
                 VCLLog.e("presentation request: \(presentationRequest.jwt.encodedJwt) \ndidDocument: \(didDocument)")
@@ -31,6 +36,10 @@ final class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByDeep
                 completionBlock: completionBlock
             )
         }
+    }
+
+    private func isDidBoundToDidDocument(_ did: String, didDocument: VCLDidDocument) -> Bool {
+        didDocument.id == did || didDocument.alsoKnownAs.contains(did)
     }
     
     private func onError(

--- a/VCL/VCL/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.swift
+++ b/VCL/VCL/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.swift
@@ -17,24 +17,25 @@ final class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByDeep
         didDocument: VCLDidDocument,
         completionBlock: @escaping (VCLResult<Bool>) -> Void
     ) {
-        if let deepLinkDid = deepLink.did {
-            if isDidBoundToDidDocument(
-                presentationRequest.iss,
-                didDocument: didDocument
-            ) && isDidBoundToDidDocument(
-                deepLinkDid,
-                didDocument: didDocument
-            ) {
-                completionBlock(.success(true))
-            } else {
-                VCLLog.e("presentation request: \(presentationRequest.jwt.encodedJwt) \ndidDocument: \(didDocument)")
-                completionBlock(.failure(VCLError(errorCode: VCLErrorCode.MismatchedPresentationRequestInspectorDid.rawValue)))
-            }
-        } else {
+        guard let deepLinkDid = deepLink.did else {
             onError(
                 errorMessage: "DID not found in deep link: \(deepLink.value)",
                 completionBlock: completionBlock
             )
+            return
+        }
+
+        if isDidBoundToDidDocument(
+            presentationRequest.iss,
+            didDocument: didDocument
+        ) && isDidBoundToDidDocument(
+            deepLinkDid,
+            didDocument: didDocument
+        ) {
+            completionBlock(.success(true))
+        } else {
+            VCLLog.e("presentation request: \(presentationRequest.jwt.encodedJwt) \ndidDocument: \(didDocument)")
+            completionBlock(.failure(VCLError(errorCode: VCLErrorCode.MismatchedPresentationRequestInspectorDid.rawValue)))
         }
     }
 

--- a/VCL/VCLTests/verifiers/PresentationRequestByDeepLinkVerifierTest.swift
+++ b/VCL/VCLTests/verifiers/PresentationRequestByDeepLinkVerifierTest.swift
@@ -36,6 +36,54 @@ class PresentationRequestByDeepLinkVerifierTest: XCTestCase {
         }
     }
 
+    func testVerifyCredentialManifestSuccessWithDidDocumentIdInDeepLink() {
+        subject = PresentationRequestByDeepLinkVerifierImpl()
+        let deepLinkWithDidDocumentId = deepLinkWithInspectorDid(DidDocumentMocks.DidDocumentMock.id)
+
+        subject.verifyPresentationRequest(
+            presentationRequest: presentationRequest,
+            deepLink: deepLinkWithDidDocumentId,
+            didDocument: DidDocumentMocks.DidDocumentMock
+        ) { isVerifiedRes in
+            do {
+                let isVerified = try isVerifiedRes.get()
+                assert(isVerified)
+            } catch {
+                XCTFail("\(error)")
+            }
+        }
+    }
+
+    func testVerifyCredentialManifestSuccessWithDidDocumentIdInPresentationRequest() {
+        subject = PresentationRequestByDeepLinkVerifierImpl()
+
+        let originalDidDocumentId = DidDocumentMocks.DidDocumentMock.id
+        var didDocumentPayload = DidDocumentMocks.DidDocumentMock.payload
+        didDocumentPayload[VCLDidDocument.CodingKeys.KeyId] = presentationRequest.iss
+
+        var alsoKnownAs = DidDocumentMocks.DidDocumentMock.alsoKnownAs
+        if !alsoKnownAs.contains(originalDidDocumentId) {
+            alsoKnownAs.append(originalDidDocumentId)
+        }
+        didDocumentPayload[VCLDidDocument.CodingKeys.KeyAlsoKnownAs] = alsoKnownAs
+
+        let didDocumentWithPresentationRequestIss = VCLDidDocument(payload: didDocumentPayload)
+        let deepLinkWithDidDocumentAlias = deepLinkWithInspectorDid(originalDidDocumentId)
+
+        subject.verifyPresentationRequest(
+            presentationRequest: presentationRequest,
+            deepLink: deepLinkWithDidDocumentAlias,
+            didDocument: didDocumentWithPresentationRequestIss
+        ) { isVerifiedRes in
+            do {
+                let isVerified = try isVerifiedRes.get()
+                assert(isVerified)
+            } catch {
+                XCTFail("\(error)")
+            }
+        }
+    }
+
     func testVerifyCredentialManifestError() {
         subject = PresentationRequestByDeepLinkVerifierImpl()
         
@@ -51,5 +99,10 @@ class PresentationRequestByDeepLinkVerifierTest: XCTestCase {
                 assert((error as! VCLError).errorCode == VCLErrorCode.MismatchedPresentationRequestInspectorDid.rawValue)
             }
         }
+    }
+
+    private func deepLinkWithInspectorDid(_ inspectorDid: String) -> VCLDeepLink {
+        let encodedInspectorDid = inspectorDid.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? inspectorDid
+        return VCLDeepLink(value: "velocity-network://inspect?inspectorDid=\(encodedInspectorDid)")
     }
 }

--- a/VCL/VCLTests/verifiers/PresentationRequestByDeepLinkVerifierTest.swift
+++ b/VCL/VCLTests/verifiers/PresentationRequestByDeepLinkVerifierTest.swift
@@ -101,6 +101,25 @@ class PresentationRequestByDeepLinkVerifierTest: XCTestCase {
         }
     }
 
+    func testVerifyPresentationRequestErrorWhenDeepLinkDidMissing() {
+        subject = PresentationRequestByDeepLinkVerifierImpl()
+
+        subject.verifyPresentationRequest(
+            presentationRequest: presentationRequest,
+            deepLink: VCLDeepLink(value: "velocity-network://inspect"),
+            didDocument: DidDocumentMocks.DidDocumentMock
+        ) { isVerifiedRes in
+            do {
+                _ = try isVerifiedRes.get()
+                XCTFail("\(VCLErrorCode.SdkError.rawValue) error code is expected")
+            } catch {
+                let vclError = error as! VCLError
+                XCTAssertEqual(vclError.errorCode, VCLErrorCode.SdkError.rawValue)
+                XCTAssertTrue(vclError.message?.contains("DID not found in deep link") == true)
+            }
+        }
+    }
+
     private func deepLinkWithInspectorDid(_ inspectorDid: String) -> VCLDeepLink {
         let encodedInspectorDid = inspectorDid.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? inspectorDid
         return VCLDeepLink(value: "velocity-network://inspect?inspectorDid=\(encodedInspectorDid)")

--- a/VCL/VCLTests/verifiers/PresentationRequestByDeepLinkVerifierTest.swift
+++ b/VCL/VCLTests/verifiers/PresentationRequestByDeepLinkVerifierTest.swift
@@ -19,7 +19,7 @@ class PresentationRequestByDeepLinkVerifierTest: XCTestCase {
 
     private let deepLink = DeepLinkMocks.PresentationRequestDeepLinkDevNet
 
-    func testVerifyCredentialManifestSuccess() {
+    func testVerifyPresentationRequestSuccess() {
         subject = PresentationRequestByDeepLinkVerifierImpl()
         
         subject.verifyPresentationRequest(
@@ -36,7 +36,7 @@ class PresentationRequestByDeepLinkVerifierTest: XCTestCase {
         }
     }
 
-    func testVerifyCredentialManifestSuccessWithDidDocumentIdInDeepLink() {
+    func testVerifyPresentationRequestSuccessWithDidDocumentIdInDeepLink() {
         subject = PresentationRequestByDeepLinkVerifierImpl()
         let deepLinkWithDidDocumentId = deepLinkWithInspectorDid(DidDocumentMocks.DidDocumentMock.id)
 
@@ -54,7 +54,7 @@ class PresentationRequestByDeepLinkVerifierTest: XCTestCase {
         }
     }
 
-    func testVerifyCredentialManifestSuccessWithDidDocumentIdInPresentationRequest() {
+    func testVerifyPresentationRequestSuccessWithDidDocumentIdInPresentationRequest() {
         subject = PresentationRequestByDeepLinkVerifierImpl()
 
         let originalDidDocumentId = DidDocumentMocks.DidDocumentMock.id
@@ -84,7 +84,7 @@ class PresentationRequestByDeepLinkVerifierTest: XCTestCase {
         }
     }
 
-    func testVerifyCredentialManifestError() {
+    func testVerifyPresentationRequestError() {
         subject = PresentationRequestByDeepLinkVerifierImpl()
         
         subject.verifyPresentationRequest(


### PR DESCRIPTION
## Summary
- update `PresentationRequestByDeepLinkVerifierImpl` to validate `presentationRequest.iss` and `deepLink.did` independently against `didDocument.id` OR `didDocument.alsoKnownAs`
- preserve mismatch error behavior for true mismatches
- add coverage for both mixed valid combinations in `PresentationRequestByDeepLinkVerifierTest`

## Why
Valid presentation requests were rejected when one DID matched `id` and the other matched `alsoKnownAs`.

## Validation
- `xcodebuild -project VCL.xcodeproj -scheme VCL -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' -only-testing:VCLTests/PresentationRequestByDeepLinkVerifierTest test`