### PR TITLE
fix(ci): remove sdk archive signing setup

### DIFF
--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -54,13 +54,8 @@ jobs:
     runs-on: macos-15
     env:
       XC_VERSION: "16.3"
-      #Certs
-      ENCRYPTED_CERTS_FILE_PATH: "./certs.p12.tar.gz.gpg"
-      DECRYPTED_CERTS_FILE_PATH: "./certs.p12.tar.gz"
-      CERTS_FILE_PATH: "./certs.p12"
       # Recomends to use separated PAT token to access to another repos
       PAT_TOKEN: ${{ secrets.VCL_RW_ACCESS_TOKEN }}
-      KEYCHAIN: "velocity.keychain"
       RC_SUFFIX: 'rc'
       GLOBAL_ENV: ${{ needs.set-environment.outputs.GLOBAL_ENV }}
     steps:
@@ -74,26 +69,6 @@ jobs:
       - name: Extract branch name
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
-      # Certificate
-      - name: Certificate
-        run: "echo ${{ secrets.APPLE_CERTS_BASE64 }} | base64 -d > ${{ env.ENCRYPTED_CERTS_FILE_PATH }}"
-      # Configure keychain and code signing
-      - name: Configure keychain and code signing
-        run: |
-          security create-keychain -p "" "${{ env.KEYCHAIN }}"
-          security list-keychains -s "${{ env.KEYCHAIN }}"
-          security unlock-keychain -p "" ${{ env.KEYCHAIN }}
-          security set-keychain-settings ${{ env.KEYCHAIN }}
-          security default-keychain -s ${{ env.KEYCHAIN }}
-          security list-keychains
-
-          gpg -d -o "${{ env.DECRYPTED_CERTS_FILE_PATH }}" --pinentry-mode=loopback --passphrase "${{ secrets.CERTS_ENCRYPTION_PWD }}" "${{ env.ENCRYPTED_CERTS_FILE_PATH }}"
-          tar xzvf ${{ env.DECRYPTED_CERTS_FILE_PATH }}
-
-          security import "${{ env.CERTS_FILE_PATH }}" -k "${{ env.KEYCHAIN }}" -P "${{ secrets.CERTS_ENCRYPTION_PWD }}" -A
-          security set-key-partition-list -S apple-tool:,apple: -s -k "" "${{ env.KEYCHAIN }}"
-
-          security find-identity -p codesigning -v
       # VCL build
       - name: VCL build
         run: scripts/build_xcframework.sh

--- a/VCL/scripts/build_xcframework.sh
+++ b/VCL/scripts/build_xcframework.sh
@@ -34,5 +34,5 @@ xcodebuild -create-xcframework \
     -framework "./build/$FRAMEWORK_NAME-iOS.xcarchive/Products/Library/Frameworks/$FRAMEWORK_NAME.framework" \
     -framework "./build/$FRAMEWORK_NAME-iOS-simulator.xcarchive/Products/Library/Frameworks/$FRAMEWORK_NAME.framework" \
     -output "./build/$FRAMEWORK_NAME.xcframework"
-# Clean up interfce naming
-find . -name "*.swiftinterface" -exec sed -i -e "s/$FRAMEWORK_NAME\.//g" {} \;
+# Clean up interface naming
+find "./build/$FRAMEWORK_NAME.xcframework" -name "*.swiftinterface" -exec sed -i '' -e "s/$FRAMEWORK_NAME\.//g" {} \;

--- a/VCL/scripts/build_xcframework.sh
+++ b/VCL/scripts/build_xcframework.sh
@@ -13,7 +13,10 @@ xcodebuild archive \
     -archivePath "./build/$FRAMEWORK_NAME-iOS.xcarchive" \
     -sdk iphoneos \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO
 # iOS simulators
 xcodebuild archive \
     -scheme $FRAMEWORK_NAME \
@@ -22,7 +25,10 @@ xcodebuild archive \
     -archivePath "./build/$FRAMEWORK_NAME-iOS-simulator.xcarchive" \
     -sdk iphonesimulator \
     SKIP_INSTALL=NO \
-    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO
 # Create the xcframework from them
 xcodebuild -create-xcframework \
     -framework "./build/$FRAMEWORK_NAME-iOS.xcarchive/Products/Library/Frameworks/$FRAMEWORK_NAME.framework" \


### PR DESCRIPTION
## Summary
- disable signing during device and simulator archive creation in the XCFramework build script
- remove certificate and keychain setup from the SDK publish workflow
- keep the SDK publish path focused on producing and publishing the XCFramework artifact

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-sdk.yml")'
- ./scripts/build_xcframework.sh (from `VCL/`)

## Notes
- this PR removes archive-time signing requirements from the SDK publish workflow
- if we want Apple SDK signatures on the distributed XCFramework, that should be added as a separate final artifact-signing step