### PR TITLE
[codex] Use VCLError.message for plain-text failures

### DIFF
--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -63,7 +63,7 @@ public struct VCLError: Error {
             self.error = nil
             self.errorCode = errorCode
             self.requestId = nil
-            self.message = "\(String(describing: error))"
+            self.message = error.map { "\($0)" }
             self.statusCode = statusCode
         }
     }

--- a/VCL/VCL/impl/data/infrastructure/network/NetworkServiceImpl.swift
+++ b/VCL/VCL/impl/data/infrastructure/network/NetworkServiceImpl.swift
@@ -73,8 +73,19 @@ final class NetworkServiceImpl: NetworkService {
                 self?.logResponse(response)
                 completionBlock(.success(response))
             } else {
+                let errorPayload = String(data: jsonData, encoding: .utf8) ?? ""
+                let parsedError = VCLError(payload: errorPayload)
+                let hasStructuredPayload = errorPayload.toDictionary() != nil
+                
                 completionBlock(.failure(
-                    VCLError(payload: String(data: jsonData, encoding: .utf8) ?? "")
+                    VCLError(
+                        payload: parsedError.payload,
+                        error: parsedError.error,
+                        errorCode: parsedError.errorCode,
+                        requestId: parsedError.requestId,
+                        message: parsedError.message ?? (hasStructuredPayload ? nil : errorPayload),
+                        statusCode: parsedError.statusCode ?? httpResponse.statusCode
+                    )
                 ))
             }
         }

--- a/VCL/VCL/impl/data/infrastructure/network/NetworkServiceImpl.swift
+++ b/VCL/VCL/impl/data/infrastructure/network/NetworkServiceImpl.swift
@@ -74,22 +74,37 @@ final class NetworkServiceImpl: NetworkService {
                 completionBlock(.success(response))
             } else {
                 let errorPayload = String(data: jsonData, encoding: .utf8) ?? ""
-                let parsedError = VCLError(payload: errorPayload)
-                let hasStructuredPayload = errorPayload.toDictionary() != nil
-                
-                completionBlock(.failure(
-                    VCLError(
-                        payload: parsedError.payload,
-                        error: parsedError.error,
-                        errorCode: parsedError.errorCode,
-                        requestId: parsedError.requestId,
-                        message: parsedError.message ?? (hasStructuredPayload ? nil : errorPayload),
-                        statusCode: parsedError.statusCode ?? httpResponse.statusCode
-                    )
-                ))
+                let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+                completionBlock(.failure(Self.createError(
+                    from: errorPayload,
+                    contentType: contentType,
+                    statusCode: httpResponse.statusCode
+                )))
             }
         }
         task.resume()
+    }
+    
+    private static func createError(from errorPayload: String, contentType: String?, statusCode: Int) -> VCLError {
+        if isJsonContentType(contentType) {
+            return VCLError(
+                error: VCLError(payload: errorPayload),
+                statusCode: statusCode
+            )
+        }
+        
+        return VCLError(
+            message: errorPayload.isEmpty ? nil : errorPayload,
+            statusCode: statusCode
+        )
+    }
+    
+    private static func isJsonContentType(_ contentType: String?) -> Bool {
+        guard let contentType = contentType?.lowercased() else {
+            return false
+        }
+        
+        return contentType.contains("application/json") || contentType.contains("+json")
     }
     
     private func createUrlRequest(request: Request) -> URLRequest? {

--- a/VCL/VCL/impl/data/repositories/AuthTokenRepositoryImpl.swift
+++ b/VCL/VCL/impl/data/repositories/AuthTokenRepositoryImpl.swift
@@ -42,7 +42,7 @@ final class AuthTokenRepositoryImpl: AuthTokenRepository {
                 } else {
                     completionBlock(
                         VCLResult.failure(
-                            VCLError(payload: "Failed to parse auth token response")
+                            VCLError(message: "Failed to parse auth token response")
                         )
                     )
                 }

--- a/VCL/VCL/impl/data/verifiers/directissuerverification/CompleteContextsStorage.swift
+++ b/VCL/VCL/impl/data/verifiers/directissuerverification/CompleteContextsStorage.swift
@@ -14,7 +14,7 @@ final class CompleteContextsStorage {
     private let queue = DispatchQueue(label: "CompleteContextsStorageQueue", attributes: .concurrent)
     
     func append(_ completeContext: [String: Any]) {
-        queue.async(flags: .barrier) {
+        queue.sync(flags: .barrier) {
             self.storage.append(completeContext)
         }
     }

--- a/VCL/VCL/impl/data/verifiers/directissuerverification/CredentialIssuerVerifierImpl.swift
+++ b/VCL/VCL/impl/data/verifiers/directissuerverification/CredentialIssuerVerifierImpl.swift
@@ -178,8 +178,16 @@ final class CredentialIssuerVerifierImpl: CredentialIssuerVerifier {
                             )
                         }
                         catch {
+                            let error = error as? VCLError ?? VCLError(error: error)
                             self?.onError(
-                                VCLError(errorCode: VCLErrorCode.InvalidCredentialSubjectContext.rawValue),
+                                VCLError(
+                                    payload: error.payload,
+                                    error: error.error,
+                                    errorCode: VCLErrorCode.InvalidCredentialSubjectContext.rawValue,
+                                    requestId: error.requestId,
+                                    message: error.message,
+                                    statusCode: error.statusCode
+                                ),
                                 completionBlock
                             )
                         }
@@ -211,6 +219,7 @@ final class CredentialIssuerVerifierImpl: CredentialIssuerVerifier {
         let group = DispatchGroup()
         
         let completeContextsStorage = CompleteContextsStorage()
+        let errorStorage = GlobalErrorStorage()
         
 //        let credentialSubjectContext = credentialSubjectContexts[0]
         for credentialSubjectContext in credentialSubjectContexts {
@@ -231,7 +240,9 @@ final class CredentialIssuerVerifierImpl: CredentialIssuerVerifier {
                         let ldContextResponse = try result.get()
                         completeContextsStorage.append(ldContextResponse)
                     } catch {
-                        VCLLog.e("\(error)")
+                        let error = error as? VCLError ?? VCLError(error: error)
+                        errorStorage.update(error)
+                        VCLLog.e(error.message ?? "\(error)")
                     }
                 }
             }
@@ -241,10 +252,14 @@ final class CredentialIssuerVerifierImpl: CredentialIssuerVerifier {
         group.wait()
         
         if completeContextsStorage.isEmpty() {
-            onError(
-                VCLError(errorCode: VCLErrorCode.InvalidCredentialSubjectContext.rawValue),
-                completionBlock
-            )
+            if let error = errorStorage.get() {
+                completionBlock(.failure(error))
+            } else {
+                onError(
+                    VCLError(errorCode: VCLErrorCode.InvalidCredentialSubjectContext.rawValue),
+                    completionBlock
+                )
+            }
         } else {
             completionBlock(.success(completeContextsStorage.get()))
         }

--- a/VCL/VCL/impl/data/verifiers/directissuerverification/CredentialIssuerVerifierImpl.swift
+++ b/VCL/VCL/impl/data/verifiers/directissuerverification/CredentialIssuerVerifierImpl.swift
@@ -178,15 +178,15 @@ final class CredentialIssuerVerifierImpl: CredentialIssuerVerifier {
                             )
                         }
                         catch {
-                            let error = error as? VCLError ?? VCLError(error: error)
+                            let vclError = error as? VCLError ?? VCLError(error: error)
                             self?.onError(
                                 VCLError(
-                                    payload: error.payload,
-                                    error: error.error,
+                                    payload: vclError.payload,
+                                    error: vclError.error,
                                     errorCode: VCLErrorCode.InvalidCredentialSubjectContext.rawValue,
-                                    requestId: error.requestId,
-                                    message: error.message,
-                                    statusCode: error.statusCode
+                                    requestId: vclError.requestId,
+                                    message: vclError.message,
+                                    statusCode: vclError.statusCode
                                 ),
                                 completionBlock
                             )
@@ -240,9 +240,9 @@ final class CredentialIssuerVerifierImpl: CredentialIssuerVerifier {
                         let ldContextResponse = try result.get()
                         completeContextsStorage.append(ldContextResponse)
                     } catch {
-                        let error = error as? VCLError ?? VCLError(error: error)
-                        errorStorage.update(error)
-                        VCLLog.e(error.message ?? "\(error)")
+                        let vclError = error as? VCLError ?? VCLError(error: error)
+                        errorStorage.update(vclError)
+                        VCLLog.e(vclError.message ?? "\(vclError)")
                     }
                 }
             }

--- a/VCL/VCL/impl/data/verifiers/directissuerverification/GlobalErrorStorage.swift
+++ b/VCL/VCL/impl/data/verifiers/directissuerverification/GlobalErrorStorage.swift
@@ -26,7 +26,7 @@ final class GlobalErrorStorage {
     }
 
     func clear() {
-        queue.async(flags: .barrier) {
+        queue.sync(flags: .barrier) {
             self.error = nil
         }
     }

--- a/VCL/VCL/impl/data/verifiers/directissuerverification/GlobalErrorStorage.swift
+++ b/VCL/VCL/impl/data/verifiers/directissuerverification/GlobalErrorStorage.swift
@@ -14,7 +14,7 @@ final class GlobalErrorStorage {
     private let queue = DispatchQueue(label: "GlobalErrorStorageQueue", attributes: .concurrent)
 
     func update(_ error: VCLError) {
-        queue.async(flags: .barrier) {
+        queue.sync(flags: .barrier) {
             self.error = error
         }
     }

--- a/VCL/VCL/impl/data/verifiers/directissuerverification/repositories/CredentialSubjectContextRepositoryImpl.swift
+++ b/VCL/VCL/impl/data/verifiers/directissuerverification/repositories/CredentialSubjectContextRepositoryImpl.swift
@@ -28,7 +28,7 @@ class CredentialSubjectContextRepositoryImpl: CredentialSubjectContextRepository
                 if let ldContextResponse = try result.get().payload.toDictionary() {
                     completionBlock(VCLResult.success(ldContextResponse))
                 } else {
-                    let error = VCLError(payload: "Unexpected LD-Context payload for \(credentialSubjectContextEndpoint)")
+                    let error = VCLError(message: "Unexpected LD-Context payload for \(credentialSubjectContextEndpoint)")
                     completionBlock(VCLResult.failure(error))
                 }
             } catch {

--- a/VCL/VCL/impl/jwt/remote/VCLJwtSignServiceRemoteImpl.swift
+++ b/VCL/VCL/impl/jwt/remote/VCLJwtSignServiceRemoteImpl.swift
@@ -40,7 +40,7 @@ final class VCLJwtSignServiceRemoteImpl: VCLJwtSignService {
                 if let jwtStr = try signedJwtResult.get().payload.toDictionary()?[CodingKeys.KeyCompactJwt] as? String {
                     completionBlock(.success(VCLJwt(encodedJwt: jwtStr)))
                 } else {
-                    completionBlock(.failure(VCLError(payload: "Failed to parse data from \(self?.jwtSignServiceUrl ?? "")")))
+                    completionBlock(.failure(VCLError(message: "Failed to parse data from \(self?.jwtSignServiceUrl ?? "")")))
                 }
             } catch {
                 completionBlock(.failure(VCLError(error: error)))

--- a/VCL/VCL/impl/keys/VCLKeyServiceLocalImpl.swift
+++ b/VCL/VCL/impl/keys/VCLKeyServiceLocalImpl.swift
@@ -69,7 +69,7 @@ final class VCLKeyServiceLocalImpl: VCLKeyService {
         if let keyId = UUID(uuidString: keyId) {
             completionBlock(.success(keyManagementOperations.retrieveKeyFromStorage(withId: keyId)))
         } else {
-            completionBlock(.failure(VCLError(payload: "Invalid UUID format of keyID: \(keyId)")))
+            completionBlock(.failure(VCLError(message: "Invalid UUID format of keyID: \(keyId)")))
         }
     }
     

--- a/VCL/VCL/impl/keys/VCLKeyServiceRemoteImpl.swift
+++ b/VCL/VCL/impl/keys/VCLKeyServiceRemoteImpl.swift
@@ -50,7 +50,7 @@ final class VCLKeyServiceRemoteImpl: VCLKeyService {
                 } else {
                     completionBlock(
                         .failure(
-                            VCLError(payload: "Failed to create did:jwk from the provided URL: \(self?.keyServiceUrls.createDidKeyServiceUrl ?? "")")
+                            VCLError(message: "Failed to create did:jwk from the provided URL: \(self?.keyServiceUrls.createDidKeyServiceUrl ?? "")")
                         )
                     )
                 }

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -12,6 +12,9 @@ import XCTest
 @testable import VCL
 
 class VCLErrorTes: XCTestCase {
+    private struct DummyError: Error, CustomStringConvertible {
+        let description: String
+    }
     
     func testErrorFromPayload() {
         let error = VCLError(payload: ErrorMocks.Payload)
@@ -74,6 +77,12 @@ class VCLErrorTes: XCTestCase {
         assert(errorFromError.requestId == error.requestId)
         assert(errorFromError.message == error.message)
     }
+    
+    func testErrorFromNonVCLErrorDoesNotWrapOptionalInMessage() {
+        let error = VCLError(error: DummyError(description: "dummy failure"))
+        
+        assert(error.message == "dummy failure")
+    }
 
     func testErrorToJsonFromPayload() {
         let error = VCLError(payload: ErrorMocks.Payload)
@@ -105,4 +114,3 @@ class VCLErrorTes: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
     }
 }
-

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -11,7 +11,7 @@ import Foundation
 import XCTest
 @testable import VCL
 
-class VCLErrorTes: XCTestCase {
+class VCLErrorTest: XCTestCase {
     private struct DummyError: Error, CustomStringConvertible {
         let description: String
     }

--- a/VCL/VCLTests/infrastructure/resources/valid/network/NetworkServiceFailure.swift
+++ b/VCL/VCLTests/infrastructure/resources/valid/network/NetworkServiceFailure.swift
@@ -26,7 +26,6 @@ final class NetworkServiceFailure: NetworkService {
             cachePolicy: NSURLRequest.CachePolicy,
             completionBlock: @escaping (VCLResult<Response>) -> Void
     ) {
-        completionBlock(.failure(VCLError(payload: errorMessage)))
+        completionBlock(.failure(VCLError(message: errorMessage)))
     }
 }
-

--- a/VCL/VCLTests/verifiers/CredentialIssuerVerifierTest.swift
+++ b/VCL/VCLTests/verifiers/CredentialIssuerVerifierTest.swift
@@ -425,9 +425,9 @@ class CredentialIssuerVerifierTest: XCTestCase {
                 let _ = try $0.get()
                 XCTFail("\(VCLErrorCode.InvalidCredentialSubjectContext.rawValue) error code is expected")
             } catch {
-                let error = error as! VCLError
-                assert(error.errorCode == VCLErrorCode.InvalidCredentialSubjectContext.rawValue)
-                assert(error.message?.contains("Unexpected LD-Context payload for") == true)
+                let vclError = error as! VCLError
+                assert(vclError.errorCode == VCLErrorCode.InvalidCredentialSubjectContext.rawValue)
+                assert(vclError.message?.contains("Unexpected LD-Context payload for") == true)
             }
         }
     }

--- a/VCL/VCLTests/verifiers/CredentialIssuerVerifierTest.swift
+++ b/VCL/VCLTests/verifiers/CredentialIssuerVerifierTest.swift
@@ -425,7 +425,9 @@ class CredentialIssuerVerifierTest: XCTestCase {
                 let _ = try $0.get()
                 XCTFail("\(VCLErrorCode.InvalidCredentialSubjectContext.rawValue) error code is expected")
             } catch {
-                assert((error as! VCLError).errorCode == VCLErrorCode.InvalidCredentialSubjectContext.rawValue)
+                let error = error as! VCLError
+                assert(error.errorCode == VCLErrorCode.InvalidCredentialSubjectContext.rawValue)
+                assert(error.message?.contains("Unexpected LD-Context payload for") == true)
             }
         }
     }


### PR DESCRIPTION
## Summary
Fix WalletIOS issue #166 by moving human-readable `VCLError` text into the standard `message` field instead of storing it as raw `payload`.

## Root cause
Several call sites were constructing `VCLError(payload: "...")` with plain-text strings. That initializer only populates `message` when the payload is structured JSON containing a `message` key, so raw strings left `message` unset.

## What changed
- Updated the clear message-only `VCLError(payload: ...)` call sites to use `message:` directly
- Updated the shared non-2xx network error path to preserve structured JSON payload parsing while also setting `message` for plain-text response bodies
- Updated the network failure test double to match the corrected error semantics

## Impact
Callers can now rely on `VCLError.message` for human-readable failures in these paths, while payload-oriented server error responses continue to preserve structured error fields.

## Validation
- Ran `xcodebuild test -project /Users/andresolave/Projects/velocity/WalletIOS/VCL/VCL.xcodeproj -scheme VCL -derivedDataPath /tmp/WalletIOSDerivedData -destination 'id=5C4B3A60-A772-4369-8057-766F9F14B82E' test`
- Result: `180` tests passed, `0` failures