### PR TITLE
feat: add native VCLError diagnostics

### DIFF
--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -22,14 +22,14 @@ jobs:
   tests-ios-sdk:
     runs-on: macos-15
     env:
-      XC_VERSION: "16.4"
+      XC_VERSION: "26.4"
     steps:
       # Git clone repository
       - name: Git clone repository
         uses: actions/checkout@v4
       # Select latest Xcode
       - name: Select latest Xcode
-        run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
+        run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app || sudo xcode-select -s /Applications/Xcode_16.4.app"
       - name: Run tests
         run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17'
         working-directory: VCL

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
       - name: Run tests
-        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
+        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4'
         working-directory: VCL
 
   set-environment:

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
       - name: Run tests
-        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4'
+        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17'
         working-directory: VCL
 
   set-environment:

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -9,14 +9,14 @@ jobs:
   tests-ios-sdk:
     runs-on: macos-15
     env:
-      XC_VERSION: "16.4"
+      XC_VERSION: "26.4"
     steps:
       # Git clone repository
       - name: Git clone repository
         uses: actions/checkout@v4
       # Select latest Xcode
       - name: Select latest Xcode
-        run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
+        run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app || sudo xcode-select -s /Applications/Xcode_16.4.app"
       - name: Run tests
         run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17'
         working-directory: VCL

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
       - name: Run tests
-        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4'
+        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17'
         working-directory: VCL

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
       - name: Run tests
-        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
+        run: xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4'
         working-directory: VCL

--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -13,22 +13,47 @@ public struct VCLError: Error {
     public struct Diagnostic {
         public let nativePlatform: String
         public let nativeErrorType: String?
-        public let nativeStackFrames: [String]?
-        public let nativeStackTop: String?
-        public let nativeCause: String?
+        public let nativeCauseType: String?
+        public let nativeCauseMessage: String?
+        public let nativeCauseStackTop: String?
+
+        fileprivate let wrapperStackFramesInternal: [String]?
+        fileprivate let causeStackFramesInternal: [String]?
 
         public init(
             nativePlatform: String = CodingKeys.ValueNativePlatformIos,
             nativeErrorType: String? = nil,
-            nativeStackFrames: [String]? = nil,
-            nativeStackTop: String? = nil,
-            nativeCause: String? = nil
+            nativeCauseType: String? = nil,
+            nativeCauseMessage: String? = nil,
+            nativeCauseStackTop: String? = nil
+        ) {
+            self.init(
+                nativePlatform: nativePlatform,
+                nativeErrorType: nativeErrorType,
+                nativeCauseType: nativeCauseType,
+                nativeCauseMessage: nativeCauseMessage,
+                nativeCauseStackTop: nativeCauseStackTop,
+                wrapperStackFramesInternal: nil,
+                causeStackFramesInternal: nil
+            )
+        }
+
+        fileprivate init(
+            nativePlatform: String = CodingKeys.ValueNativePlatformIos,
+            nativeErrorType: String? = nil,
+            nativeCauseType: String? = nil,
+            nativeCauseMessage: String? = nil,
+            nativeCauseStackTop: String? = nil,
+            wrapperStackFramesInternal: [String]? = nil,
+            causeStackFramesInternal: [String]? = nil
         ) {
             self.nativePlatform = nativePlatform
             self.nativeErrorType = nativeErrorType
-            self.nativeStackFrames = nativeStackFrames
-            self.nativeStackTop = nativeStackTop
-            self.nativeCause = nativeCause
+            self.nativeCauseType = nativeCauseType
+            self.nativeCauseMessage = nativeCauseMessage
+            self.nativeCauseStackTop = nativeCauseStackTop
+            self.wrapperStackFramesInternal = wrapperStackFramesInternal
+            self.causeStackFramesInternal = causeStackFramesInternal
         }
 
         func toDictionary() -> [String: Any] {
@@ -39,14 +64,14 @@ public struct VCLError: Error {
             if let nativeErrorType {
                 dictionary[CodingKeys.KeyNativeErrorType] = nativeErrorType
             }
-            if let nativeStackFrames {
-                dictionary[CodingKeys.KeyNativeStackFrames] = nativeStackFrames
+            if let nativeCauseType {
+                dictionary[CodingKeys.KeyNativeCauseType] = nativeCauseType
             }
-            if let nativeStackTop {
-                dictionary[CodingKeys.KeyNativeStackTop] = nativeStackTop
+            if let nativeCauseMessage {
+                dictionary[CodingKeys.KeyNativeCauseMessage] = nativeCauseMessage
             }
-            if let nativeCause {
-                dictionary[CodingKeys.KeyNativeCause] = nativeCause
+            if let nativeCauseStackTop {
+                dictionary[CodingKeys.KeyNativeCauseStackTop] = nativeCauseStackTop
             }
 
             return dictionary
@@ -55,9 +80,9 @@ public struct VCLError: Error {
         public struct CodingKeys {
             public static let KeyNativePlatform = "nativePlatform"
             public static let KeyNativeErrorType = "nativeErrorType"
-            public static let KeyNativeStackFrames = "nativeStackFrames"
-            public static let KeyNativeStackTop = "nativeStackTop"
-            public static let KeyNativeCause = "nativeCause"
+            public static let KeyNativeCauseType = "nativeCauseType"
+            public static let KeyNativeCauseMessage = "nativeCauseMessage"
+            public static let KeyNativeCauseStackTop = "nativeCauseStackTop"
             public static let ValueNativePlatformIos = "ios"
         }
     }
@@ -146,26 +171,39 @@ public struct VCLError: Error {
     }
 
     private static func captureDiagnostic(from error: Error) -> Diagnostic {
+        let underlyingError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? Error
+
         return captureDiagnostic(
             nativeErrorType: String(describing: type(of: error)),
-            nativeCause: ((error as NSError).userInfo[NSUnderlyingErrorKey]).map { "\($0)" }
+            wrapperStackFramesInternal: Thread.callStackSymbols,
+            nativeCauseType: underlyingError.map { String(describing: type(of: $0)) },
+            nativeCauseMessage: underlyingError.map { "\($0)" },
+            causeStackFramesInternal: causeStackFrames(from: underlyingError)
         )
     }
 
     private static func captureDiagnostic(
         nativeErrorType: String,
-        nativeCause: String? = nil
+        wrapperStackFramesInternal: [String] = Thread.callStackSymbols,
+        nativeCauseType: String? = nil,
+        nativeCauseMessage: String? = nil,
+        causeStackFramesInternal: [String]? = nil
     ) -> Diagnostic {
-        let nativeStackFrames = Thread.callStackSymbols
-            .filter { !$0.contains("VCLError") && !$0.contains("captureDiagnostic") }
-            .prefix(CodingKeys.MaxDiagnosticStackFrames)
-
         return Diagnostic(
             nativeErrorType: nativeErrorType,
-            nativeStackFrames: nativeStackFrames.isEmpty ? nil : Array(nativeStackFrames),
-            nativeStackTop: nativeStackFrames.first,
-            nativeCause: nativeCause
+            nativeCauseType: nativeCauseType,
+            nativeCauseMessage: nativeCauseMessage,
+            nativeCauseStackTop: causeStackFramesInternal?.first,
+            wrapperStackFramesInternal: wrapperStackFramesInternal,
+            causeStackFramesInternal: causeStackFramesInternal
         )
+    }
+
+    private static func causeStackFrames(from error: Error?) -> [String]? {
+        if let vclError = error as? VCLError {
+            return vclError.diagnostic?.wrapperStackFramesInternal
+        }
+        return nil
     }
     
     public struct CodingKeys {
@@ -177,6 +215,5 @@ public struct VCLError: Error {
         public static let KeyStatusCode = "statusCode"
         public static let KeyDiagnostic = "diagnostic"
         public static let ValuePayloadDiagnosticType = "VCLErrorPayload"
-        public static let MaxDiagnosticStackFrames = 5
     }
 }

--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -41,14 +41,13 @@ public struct VCLError: Error {
         errorCode: String? = nil
     ) {
         let payloadJson = payload?.toDictionary()
-        self.init(
-            payload: payload,
-            error: payloadJson?[CodingKeys.KeyError] as? String,
-            errorCode: (errorCode ?? payloadJson?[CodingKeys.KeyErrorCode] as? String) ?? VCLErrorCode.SdkError.rawValue,
-            requestId: payloadJson?[CodingKeys.KeyRequestId] as? String,
-            message: payloadJson?[CodingKeys.KeyMessage] as? String,
-            statusCode: payloadJson?[CodingKeys.KeyStatusCode] as? Int
-        )
+        self.payload = payload
+        self.error = payloadJson?[CodingKeys.KeyError] as? String
+        self.errorCode = (errorCode ?? payloadJson?[CodingKeys.KeyErrorCode] as? String) ?? VCLErrorCode.SdkError.rawValue
+        self.requestId = payloadJson?[CodingKeys.KeyRequestId] as? String
+        self.message = payloadJson?[CodingKeys.KeyMessage] as? String
+        self.statusCode = payloadJson?[CodingKeys.KeyStatusCode] as? Int
+        self.cause = nil
     }
     
     public init(
@@ -57,22 +56,21 @@ public struct VCLError: Error {
         statusCode: Int? = nil
     ) {
         if let vclError = error as? VCLError {
-            self.init(
-                payload: vclError.payload,
-                error: vclError.error,
-                errorCode: vclError.errorCode,
-                requestId: vclError.requestId,
-                message: vclError.message,
-                statusCode: vclError.statusCode ?? statusCode,
-                cause: vclError.cause
-            )
+            self.payload = vclError.payload
+            self.error = vclError.error
+            self.errorCode = vclError.errorCode
+            self.requestId = vclError.requestId
+            self.message = vclError.message
+            self.statusCode = vclError.statusCode ?? statusCode
+            self.cause = vclError.cause
         } else {
-            self.init(
-                errorCode: errorCode,
-                message: error.map { "\($0)" },
-                statusCode: statusCode,
-                cause: error
-            )
+            self.payload = nil
+            self.error = nil
+            self.errorCode = errorCode
+            self.requestId = nil
+            self.message = error.map { "\($0)" }
+            self.statusCode = statusCode
+            self.cause = error
         }
     }
 

--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -15,45 +15,17 @@ public struct VCLError: Error {
         public let nativeErrorType: String?
         public let nativeCauseType: String?
         public let nativeCauseMessage: String?
-        public let nativeCauseStackTop: String?
-
-        fileprivate let wrapperStackFramesInternal: [String]?
-        fileprivate let causeStackFramesInternal: [String]?
 
         public init(
             nativePlatform: String = CodingKeys.ValueNativePlatformIos,
             nativeErrorType: String? = nil,
             nativeCauseType: String? = nil,
-            nativeCauseMessage: String? = nil,
-            nativeCauseStackTop: String? = nil
-        ) {
-            self.init(
-                nativePlatform: nativePlatform,
-                nativeErrorType: nativeErrorType,
-                nativeCauseType: nativeCauseType,
-                nativeCauseMessage: nativeCauseMessage,
-                nativeCauseStackTop: nativeCauseStackTop,
-                wrapperStackFramesInternal: nil,
-                causeStackFramesInternal: nil
-            )
-        }
-
-        fileprivate init(
-            nativePlatform: String = CodingKeys.ValueNativePlatformIos,
-            nativeErrorType: String? = nil,
-            nativeCauseType: String? = nil,
-            nativeCauseMessage: String? = nil,
-            nativeCauseStackTop: String? = nil,
-            wrapperStackFramesInternal: [String]? = nil,
-            causeStackFramesInternal: [String]? = nil
+            nativeCauseMessage: String? = nil
         ) {
             self.nativePlatform = nativePlatform
             self.nativeErrorType = nativeErrorType
             self.nativeCauseType = nativeCauseType
             self.nativeCauseMessage = nativeCauseMessage
-            self.nativeCauseStackTop = nativeCauseStackTop
-            self.wrapperStackFramesInternal = wrapperStackFramesInternal
-            self.causeStackFramesInternal = causeStackFramesInternal
         }
 
         func toDictionary() -> [String: Any] {
@@ -70,9 +42,6 @@ public struct VCLError: Error {
             if let nativeCauseMessage {
                 dictionary[CodingKeys.KeyNativeCauseMessage] = nativeCauseMessage
             }
-            if let nativeCauseStackTop {
-                dictionary[CodingKeys.KeyNativeCauseStackTop] = nativeCauseStackTop
-            }
 
             return dictionary
         }
@@ -82,7 +51,6 @@ public struct VCLError: Error {
             public static let KeyNativeErrorType = "nativeErrorType"
             public static let KeyNativeCauseType = "nativeCauseType"
             public static let KeyNativeCauseMessage = "nativeCauseMessage"
-            public static let KeyNativeCauseStackTop = "nativeCauseStackTop"
             public static let ValueNativePlatformIos = "ios"
         }
     }
@@ -94,6 +62,8 @@ public struct VCLError: Error {
     public let message: String?
     public let statusCode: Int?
     public let diagnostic: Diagnostic?
+    fileprivate var wrapperStackFramesInternal: [String]?
+    fileprivate var causeStackFramesInternal: [String]?
 
     public init(
         payload: String? = nil,
@@ -111,6 +81,8 @@ public struct VCLError: Error {
         self.message = message
         self.statusCode = statusCode
         self.diagnostic = diagnostic
+        self.wrapperStackFramesInternal = nil
+        self.causeStackFramesInternal = nil
     }
 
     public init(
@@ -118,13 +90,16 @@ public struct VCLError: Error {
         errorCode: String? = nil
     ) {
         let payloadJson = payload?.toDictionary()
-        self.payload = payload
-        self.error = payloadJson?[CodingKeys.KeyError] as? String
-        self.errorCode = (errorCode ?? payloadJson?[CodingKeys.KeyErrorCode] as? String) ?? VCLErrorCode.SdkError.rawValue
-        self.requestId = payloadJson?[CodingKeys.KeyRequestId] as? String
-        self.message = payloadJson?[CodingKeys.KeyMessage] as? String
-        self.statusCode = payloadJson?[CodingKeys.KeyStatusCode] as? Int
-        self.diagnostic = Self.captureDiagnostic(nativeErrorType: CodingKeys.ValuePayloadDiagnosticType)
+        self.init(
+            payload: payload,
+            error: payloadJson?[CodingKeys.KeyError] as? String,
+            errorCode: (errorCode ?? payloadJson?[CodingKeys.KeyErrorCode] as? String) ?? VCLErrorCode.SdkError.rawValue,
+            requestId: payloadJson?[CodingKeys.KeyRequestId] as? String,
+            message: payloadJson?[CodingKeys.KeyMessage] as? String,
+            statusCode: payloadJson?[CodingKeys.KeyStatusCode] as? Int,
+            diagnostic: Self.captureDiagnostic(nativeErrorType: CodingKeys.ValuePayloadDiagnosticType)
+        )
+        self.wrapperStackFramesInternal = Thread.callStackSymbols
     }
     
     public init(
@@ -133,21 +108,26 @@ public struct VCLError: Error {
         statusCode: Int? = nil
     ) {
         if let vclError = error as? VCLError {
-            self.payload = vclError.payload
-            self.error = vclError.error
-            self.errorCode = vclError.errorCode
-            self.requestId = vclError.requestId
-            self.message = vclError.message
-            self.statusCode = vclError.statusCode ?? statusCode
-            self.diagnostic = vclError.diagnostic
+            self.init(
+                payload: vclError.payload,
+                error: vclError.error,
+                errorCode: vclError.errorCode,
+                requestId: vclError.requestId,
+                message: vclError.message,
+                statusCode: vclError.statusCode ?? statusCode,
+                diagnostic: vclError.diagnostic
+            )
+            self.wrapperStackFramesInternal = vclError.wrapperStackFramesInternal
+            self.causeStackFramesInternal = vclError.causeStackFramesInternal
         } else {
-            self.payload = nil
-            self.error = nil
-            self.errorCode = errorCode
-            self.requestId = nil
-            self.message = error.map { "\($0)" }
-            self.statusCode = statusCode
-            self.diagnostic = error.map { Self.captureDiagnostic(from: $0) }
+            self.init(
+                errorCode: errorCode,
+                message: error.map { "\($0)" },
+                statusCode: statusCode,
+                diagnostic: error.map { Self.captureDiagnostic(from: $0) }
+            )
+            self.wrapperStackFramesInternal = error.map { _ in Thread.callStackSymbols }
+            self.causeStackFramesInternal = Self.causeStackFrames(from: (error as NSError?)?.userInfo[NSUnderlyingErrorKey] as? Error)
         }
     }
 
@@ -170,38 +150,23 @@ public struct VCLError: Error {
         return dictionary
     }
 
+    private static func captureDiagnostic(nativeErrorType: String) -> Diagnostic {
+        return Diagnostic(nativeErrorType: nativeErrorType)
+    }
+
     private static func captureDiagnostic(from error: Error) -> Diagnostic {
         let underlyingError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? Error
 
-        return captureDiagnostic(
-            nativeErrorType: String(describing: type(of: error)),
-            wrapperStackFramesInternal: Thread.callStackSymbols,
-            nativeCauseType: underlyingError.map { String(describing: type(of: $0)) },
-            nativeCauseMessage: underlyingError.map { "\($0)" },
-            causeStackFramesInternal: causeStackFrames(from: underlyingError)
-        )
-    }
-
-    private static func captureDiagnostic(
-        nativeErrorType: String,
-        wrapperStackFramesInternal: [String] = Thread.callStackSymbols,
-        nativeCauseType: String? = nil,
-        nativeCauseMessage: String? = nil,
-        causeStackFramesInternal: [String]? = nil
-    ) -> Diagnostic {
         return Diagnostic(
-            nativeErrorType: nativeErrorType,
-            nativeCauseType: nativeCauseType,
-            nativeCauseMessage: nativeCauseMessage,
-            nativeCauseStackTop: causeStackFramesInternal?.first,
-            wrapperStackFramesInternal: wrapperStackFramesInternal,
-            causeStackFramesInternal: causeStackFramesInternal
+            nativeErrorType: String(describing: type(of: error)),
+            nativeCauseType: underlyingError.map { String(describing: type(of: $0)) },
+            nativeCauseMessage: underlyingError.map { "\($0)" }
         )
     }
 
     private static func causeStackFrames(from error: Error?) -> [String]? {
         if let vclError = error as? VCLError {
-            return vclError.diagnostic?.wrapperStackFramesInternal
+            return vclError.wrapperStackFramesInternal
         }
         return nil
     }

--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -10,12 +10,54 @@
 import Foundation
 
 public struct VCLError: Error {
+    public struct Diagnostic {
+        public let nativePlatform: String
+        public let nativeErrorType: String?
+        public let nativeStackFrames: [String]?
+        public let nativeStackTop: String?
+        public let nativeCause: String?
+
+        public init(
+            nativePlatform: String = CodingKeys.ValueNativePlatformIos,
+            nativeErrorType: String? = nil,
+            nativeStackFrames: [String]? = nil,
+            nativeStackTop: String? = nil,
+            nativeCause: String? = nil
+        ) {
+            self.nativePlatform = nativePlatform
+            self.nativeErrorType = nativeErrorType
+            self.nativeStackFrames = nativeStackFrames
+            self.nativeStackTop = nativeStackTop
+            self.nativeCause = nativeCause
+        }
+
+        func toDictionary() -> [String: Any?] {
+            return [
+                CodingKeys.KeyNativePlatform: nativePlatform,
+                CodingKeys.KeyNativeErrorType: nativeErrorType,
+                CodingKeys.KeyNativeStackFrames: nativeStackFrames,
+                CodingKeys.KeyNativeStackTop: nativeStackTop,
+                CodingKeys.KeyNativeCause: nativeCause
+            ]
+        }
+
+        public struct CodingKeys {
+            public static let KeyNativePlatform = "nativePlatform"
+            public static let KeyNativeErrorType = "nativeErrorType"
+            public static let KeyNativeStackFrames = "nativeStackFrames"
+            public static let KeyNativeStackTop = "nativeStackTop"
+            public static let KeyNativeCause = "nativeCause"
+            public static let ValueNativePlatformIos = "ios"
+        }
+    }
+
     public let payload: String?
     public let error: String?
     public let errorCode: String
     public let requestId: String?
     public let message: String?
     public let statusCode: Int?
+    public let diagnostic: Diagnostic?
 
     public init(
         payload: String? = nil,
@@ -23,7 +65,8 @@ public struct VCLError: Error {
         errorCode: String = VCLErrorCode.SdkError.rawValue,
         requestId: String? = nil,
         message: String? = nil,
-        statusCode: Int? = nil
+        statusCode: Int? = nil,
+        diagnostic: Diagnostic? = nil
     ) {
         self.payload = payload
         self.error = error
@@ -31,6 +74,7 @@ public struct VCLError: Error {
         self.requestId = requestId
         self.message = message
         self.statusCode = statusCode
+        self.diagnostic = diagnostic
     }
 
     public init(
@@ -44,6 +88,7 @@ public struct VCLError: Error {
         self.requestId = payloadJson?[CodingKeys.KeyRequestId] as? String
         self.message = payloadJson?[CodingKeys.KeyMessage] as? String
         self.statusCode = payloadJson?[CodingKeys.KeyStatusCode] as? Int
+        self.diagnostic = Self.captureDiagnostic(nativeErrorType: CodingKeys.ValuePayloadDiagnosticType)
     }
     
     public init(
@@ -58,6 +103,7 @@ public struct VCLError: Error {
             self.requestId = vclError.requestId
             self.message = vclError.message
             self.statusCode = vclError.statusCode ?? statusCode
+            self.diagnostic = vclError.diagnostic
         } else {
             self.payload = nil
             self.error = nil
@@ -65,6 +111,7 @@ public struct VCLError: Error {
             self.requestId = nil
             self.message = error.map { "\($0)" }
             self.statusCode = statusCode
+            self.diagnostic = error.map { Self.captureDiagnostic(from: $0) }
         }
     }
 
@@ -75,8 +122,30 @@ public struct VCLError: Error {
             CodingKeys.KeyErrorCode: errorCode,
             CodingKeys.KeyRequestId: requestId,
             CodingKeys.KeyMessage: message,
-            CodingKeys.KeyStatusCode: statusCode
+            CodingKeys.KeyStatusCode: statusCode,
+            CodingKeys.KeyDiagnostic: diagnostic?.toDictionary()
         ]
+    }
+
+    private static func captureDiagnostic(from error: Error) -> Diagnostic {
+        return captureDiagnostic(
+            nativeErrorType: String(describing: type(of: error)),
+            nativeCause: ((error as NSError).userInfo[NSUnderlyingErrorKey]).map { "\($0)" }
+        )
+    }
+
+    private static func captureDiagnostic(
+        nativeErrorType: String,
+        nativeCause: String? = nil
+    ) -> Diagnostic {
+        let nativeStackFrames = Thread.callStackSymbols
+
+        return Diagnostic(
+            nativeErrorType: nativeErrorType,
+            nativeStackFrames: nativeStackFrames.isEmpty ? nil : nativeStackFrames,
+            nativeStackTop: nativeStackFrames.first,
+            nativeCause: nativeCause
+        )
     }
     
     public struct CodingKeys {
@@ -86,5 +155,7 @@ public struct VCLError: Error {
         public static let KeyRequestId = "requestId"
         public static let KeyMessage = "message"
         public static let KeyStatusCode = "statusCode"
+        public static let KeyDiagnostic = "diagnostic"
+        public static let ValuePayloadDiagnosticType = "VCLErrorPayload"
     }
 }

--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -10,60 +10,13 @@
 import Foundation
 
 public struct VCLError: Error {
-    public struct Diagnostic {
-        public let nativePlatform: String
-        public let nativeErrorType: String?
-        public let nativeCauseType: String?
-        public let nativeCauseMessage: String?
-
-        public init(
-            nativePlatform: String = CodingKeys.ValueNativePlatformIos,
-            nativeErrorType: String? = nil,
-            nativeCauseType: String? = nil,
-            nativeCauseMessage: String? = nil
-        ) {
-            self.nativePlatform = nativePlatform
-            self.nativeErrorType = nativeErrorType
-            self.nativeCauseType = nativeCauseType
-            self.nativeCauseMessage = nativeCauseMessage
-        }
-
-        func toDictionary() -> [String: Any] {
-            var dictionary: [String: Any] = [
-                CodingKeys.KeyNativePlatform: nativePlatform
-            ]
-
-            if let nativeErrorType {
-                dictionary[CodingKeys.KeyNativeErrorType] = nativeErrorType
-            }
-            if let nativeCauseType {
-                dictionary[CodingKeys.KeyNativeCauseType] = nativeCauseType
-            }
-            if let nativeCauseMessage {
-                dictionary[CodingKeys.KeyNativeCauseMessage] = nativeCauseMessage
-            }
-
-            return dictionary
-        }
-
-        public struct CodingKeys {
-            public static let KeyNativePlatform = "nativePlatform"
-            public static let KeyNativeErrorType = "nativeErrorType"
-            public static let KeyNativeCauseType = "nativeCauseType"
-            public static let KeyNativeCauseMessage = "nativeCauseMessage"
-            public static let ValueNativePlatformIos = "ios"
-        }
-    }
-
     public let payload: String?
     public let error: String?
     public let errorCode: String
     public let requestId: String?
     public let message: String?
     public let statusCode: Int?
-    public let diagnostic: Diagnostic?
-    fileprivate var wrapperStackFramesInternal: [String]?
-    fileprivate var causeStackFramesInternal: [String]?
+    public let cause: Error?
 
     public init(
         payload: String? = nil,
@@ -72,7 +25,7 @@ public struct VCLError: Error {
         requestId: String? = nil,
         message: String? = nil,
         statusCode: Int? = nil,
-        diagnostic: Diagnostic? = nil
+        cause: Error? = nil
     ) {
         self.payload = payload
         self.error = error
@@ -80,9 +33,7 @@ public struct VCLError: Error {
         self.requestId = requestId
         self.message = message
         self.statusCode = statusCode
-        self.diagnostic = diagnostic
-        self.wrapperStackFramesInternal = nil
-        self.causeStackFramesInternal = nil
+        self.cause = cause
     }
 
     public init(
@@ -96,10 +47,8 @@ public struct VCLError: Error {
             errorCode: (errorCode ?? payloadJson?[CodingKeys.KeyErrorCode] as? String) ?? VCLErrorCode.SdkError.rawValue,
             requestId: payloadJson?[CodingKeys.KeyRequestId] as? String,
             message: payloadJson?[CodingKeys.KeyMessage] as? String,
-            statusCode: payloadJson?[CodingKeys.KeyStatusCode] as? Int,
-            diagnostic: Self.captureDiagnostic(nativeErrorType: CodingKeys.ValuePayloadDiagnosticType)
+            statusCode: payloadJson?[CodingKeys.KeyStatusCode] as? Int
         )
-        self.wrapperStackFramesInternal = Thread.callStackSymbols
     }
     
     public init(
@@ -115,19 +64,15 @@ public struct VCLError: Error {
                 requestId: vclError.requestId,
                 message: vclError.message,
                 statusCode: vclError.statusCode ?? statusCode,
-                diagnostic: vclError.diagnostic
+                cause: vclError.cause
             )
-            self.wrapperStackFramesInternal = vclError.wrapperStackFramesInternal
-            self.causeStackFramesInternal = vclError.causeStackFramesInternal
         } else {
             self.init(
                 errorCode: errorCode,
                 message: error.map { "\($0)" },
                 statusCode: statusCode,
-                diagnostic: error.map { Self.captureDiagnostic(from: $0) }
+                cause: error
             )
-            self.wrapperStackFramesInternal = error.map { _ in Thread.callStackSymbols }
-            self.causeStackFramesInternal = Self.causeStackFrames(from: (error as NSError?)?.userInfo[NSUnderlyingErrorKey] as? Error)
         }
     }
 
@@ -141,35 +86,6 @@ public struct VCLError: Error {
             CodingKeys.KeyStatusCode: statusCode
         ]
     }
-
-    public func toDiagnosticDictionary() -> [String: Any] {
-        var dictionary = toDictionary().compactMapValues { $0 }
-        if let diagnostic {
-            dictionary[CodingKeys.KeyDiagnostic] = diagnostic.toDictionary()
-        }
-        return dictionary
-    }
-
-    private static func captureDiagnostic(nativeErrorType: String) -> Diagnostic {
-        return Diagnostic(nativeErrorType: nativeErrorType)
-    }
-
-    private static func captureDiagnostic(from error: Error) -> Diagnostic {
-        let underlyingError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? Error
-
-        return Diagnostic(
-            nativeErrorType: String(describing: type(of: error)),
-            nativeCauseType: underlyingError.map { String(describing: type(of: $0)) },
-            nativeCauseMessage: underlyingError.map { "\($0)" }
-        )
-    }
-
-    private static func causeStackFrames(from error: Error?) -> [String]? {
-        if let vclError = error as? VCLError {
-            return vclError.wrapperStackFramesInternal
-        }
-        return nil
-    }
     
     public struct CodingKeys {
         public static let KeyPayload = "payload"
@@ -178,7 +94,5 @@ public struct VCLError: Error {
         public static let KeyRequestId = "requestId"
         public static let KeyMessage = "message"
         public static let KeyStatusCode = "statusCode"
-        public static let KeyDiagnostic = "diagnostic"
-        public static let ValuePayloadDiagnosticType = "VCLErrorPayload"
     }
 }

--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -17,6 +17,7 @@ public struct VCLError: Error {
     public let message: String?
     public let statusCode: Int?
     public let cause: Error?
+    internal let callStackSymbols: [String]?
 
     public init(
         payload: String? = nil,
@@ -34,6 +35,7 @@ public struct VCLError: Error {
         self.message = message
         self.statusCode = statusCode
         self.cause = cause
+        self.callStackSymbols = Thread.callStackSymbols
     }
 
     public init(
@@ -48,6 +50,7 @@ public struct VCLError: Error {
         self.message = payloadJson?[CodingKeys.KeyMessage] as? String
         self.statusCode = payloadJson?[CodingKeys.KeyStatusCode] as? Int
         self.cause = nil
+        self.callStackSymbols = Thread.callStackSymbols
     }
     
     public init(
@@ -63,6 +66,7 @@ public struct VCLError: Error {
             self.message = vclError.message
             self.statusCode = vclError.statusCode ?? statusCode
             self.cause = vclError.cause
+            self.callStackSymbols = vclError.callStackSymbols
         } else {
             self.payload = nil
             self.error = nil
@@ -71,6 +75,7 @@ public struct VCLError: Error {
             self.message = error.map { "\($0)" }
             self.statusCode = statusCode
             self.cause = error
+            self.callStackSymbols = Thread.callStackSymbols
         }
     }
 

--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -31,14 +31,25 @@ public struct VCLError: Error {
             self.nativeCause = nativeCause
         }
 
-        func toDictionary() -> [String: Any?] {
-            return [
-                CodingKeys.KeyNativePlatform: nativePlatform,
-                CodingKeys.KeyNativeErrorType: nativeErrorType,
-                CodingKeys.KeyNativeStackFrames: nativeStackFrames,
-                CodingKeys.KeyNativeStackTop: nativeStackTop,
-                CodingKeys.KeyNativeCause: nativeCause
+        func toDictionary() -> [String: Any] {
+            var dictionary: [String: Any] = [
+                CodingKeys.KeyNativePlatform: nativePlatform
             ]
+
+            if let nativeErrorType {
+                dictionary[CodingKeys.KeyNativeErrorType] = nativeErrorType
+            }
+            if let nativeStackFrames {
+                dictionary[CodingKeys.KeyNativeStackFrames] = nativeStackFrames
+            }
+            if let nativeStackTop {
+                dictionary[CodingKeys.KeyNativeStackTop] = nativeStackTop
+            }
+            if let nativeCause {
+                dictionary[CodingKeys.KeyNativeCause] = nativeCause
+            }
+
+            return dictionary
         }
 
         public struct CodingKeys {
@@ -122,9 +133,16 @@ public struct VCLError: Error {
             CodingKeys.KeyErrorCode: errorCode,
             CodingKeys.KeyRequestId: requestId,
             CodingKeys.KeyMessage: message,
-            CodingKeys.KeyStatusCode: statusCode,
-            CodingKeys.KeyDiagnostic: diagnostic?.toDictionary()
+            CodingKeys.KeyStatusCode: statusCode
         ]
+    }
+
+    public func toDiagnosticDictionary() -> [String: Any] {
+        var dictionary = toDictionary().compactMapValues { $0 }
+        if let diagnostic {
+            dictionary[CodingKeys.KeyDiagnostic] = diagnostic.toDictionary()
+        }
+        return dictionary
     }
 
     private static func captureDiagnostic(from error: Error) -> Diagnostic {
@@ -139,10 +157,12 @@ public struct VCLError: Error {
         nativeCause: String? = nil
     ) -> Diagnostic {
         let nativeStackFrames = Thread.callStackSymbols
+            .filter { !$0.contains("VCLError") && !$0.contains("captureDiagnostic") }
+            .prefix(CodingKeys.MaxDiagnosticStackFrames)
 
         return Diagnostic(
             nativeErrorType: nativeErrorType,
-            nativeStackFrames: nativeStackFrames.isEmpty ? nil : nativeStackFrames,
+            nativeStackFrames: nativeStackFrames.isEmpty ? nil : Array(nativeStackFrames),
             nativeStackTop: nativeStackFrames.first,
             nativeCause: nativeCause
         )
@@ -157,5 +177,6 @@ public struct VCLError: Error {
         public static let KeyStatusCode = "statusCode"
         public static let KeyDiagnostic = "diagnostic"
         public static let ValuePayloadDiagnosticType = "VCLErrorPayload"
+        public static let MaxDiagnosticStackFrames = 5
     }
 }

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -15,6 +15,13 @@ class VCLErrorTest: XCTestCase {
     private struct DummyError: Error, CustomStringConvertible {
         let description: String
     }
+
+    private let diagnostic = VCLError.Diagnostic(
+        nativeErrorType: "NativeErrorType",
+        nativeStackFrames: ["frame 1", "frame 2"],
+        nativeStackTop: "frame 1",
+        nativeCause: "NativeCause"
+    )
     
     func testErrorFromPayload() {
         let error = VCLError(payload: ErrorMocks.Payload)
@@ -25,6 +32,10 @@ class VCLErrorTest: XCTestCase {
         assert(error.requestId == ErrorMocks.RequestId)
         assert(error.message == ErrorMocks.Message)
         assert(error.statusCode == ErrorMocks.StatusCode)
+        assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
+        assert(error.diagnostic?.nativeErrorType == VCLError.CodingKeys.ValuePayloadDiagnosticType)
+        assert(error.diagnostic?.nativeStackFrames?.isEmpty == false)
+        assert(error.diagnostic?.nativeStackTop == error.diagnostic?.nativeStackFrames?.first)
     }
     
     func testErrorFromProperties() {
@@ -33,7 +44,8 @@ class VCLErrorTest: XCTestCase {
             errorCode: ErrorMocks.ErrorCode,
             requestId: ErrorMocks.RequestId,
             message: ErrorMocks.Message,
-            statusCode: ErrorMocks.StatusCode
+            statusCode: ErrorMocks.StatusCode,
+            diagnostic: diagnostic
         )
         
         assert(error.payload == nil)
@@ -42,6 +54,11 @@ class VCLErrorTest: XCTestCase {
         assert(error.requestId == ErrorMocks.RequestId)
         assert(error.message == ErrorMocks.Message)
         assert(error.statusCode == ErrorMocks.StatusCode)
+        assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
+        assert(error.diagnostic?.nativeErrorType == diagnostic.nativeErrorType)
+        assert(error.diagnostic?.nativeStackFrames == diagnostic.nativeStackFrames)
+        assert(error.diagnostic?.nativeStackTop == diagnostic.nativeStackTop)
+        assert(error.diagnostic?.nativeCause == diagnostic.nativeCause)
     }
     
     func testErrorFromError1() {
@@ -50,7 +67,8 @@ class VCLErrorTest: XCTestCase {
             errorCode: ErrorMocks.ErrorCode,
             requestId: ErrorMocks.RequestId,
             message: ErrorMocks.Message,
-            statusCode: ErrorMocks.StatusCode
+            statusCode: ErrorMocks.StatusCode,
+            diagnostic: diagnostic
         )
         let errorFromError = VCLError(error: error)
         
@@ -60,6 +78,11 @@ class VCLErrorTest: XCTestCase {
         assert(error.requestId == errorFromError.requestId)
         assert(error.message == errorFromError.message)
         assert(error.statusCode == errorFromError.statusCode)
+        assert(error.diagnostic?.nativePlatform == errorFromError.diagnostic?.nativePlatform)
+        assert(error.diagnostic?.nativeErrorType == errorFromError.diagnostic?.nativeErrorType)
+        assert(error.diagnostic?.nativeStackFrames == errorFromError.diagnostic?.nativeStackFrames)
+        assert(error.diagnostic?.nativeStackTop == errorFromError.diagnostic?.nativeStackTop)
+        assert(error.diagnostic?.nativeCause == errorFromError.diagnostic?.nativeCause)
     }
     
     func testErrorFromError2() {
@@ -82,11 +105,16 @@ class VCLErrorTest: XCTestCase {
         let error = VCLError(error: DummyError(description: "dummy failure"))
         
         assert(error.message == "dummy failure")
+        assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
+        assert(error.diagnostic?.nativeErrorType == "DummyError")
+        assert(error.diagnostic?.nativeStackFrames?.isEmpty == false)
+        assert(error.diagnostic?.nativeStackTop == error.diagnostic?.nativeStackFrames?.first)
     }
 
     func testErrorToJsonFromPayload() {
         let error = VCLError(payload: ErrorMocks.Payload)
         let errorDictionary = error.toDictionary()
+        let diagnosticDictionary = errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any?]
 
         assert(errorDictionary[VCLError.CodingKeys.KeyPayload] as? String == ErrorMocks.Payload)
         assert(errorDictionary[VCLError.CodingKeys.KeyError] as? String == ErrorMocks.Error)
@@ -94,6 +122,11 @@ class VCLErrorTest: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyRequestId] as? String == ErrorMocks.RequestId)
         assert(errorDictionary[VCLError.CodingKeys.KeyMessage] as? String == ErrorMocks.Message)
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == VCLError.CodingKeys.ValuePayloadDiagnosticType)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackFrames] as? [String] != nil)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackTop] as? String != nil)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCause] as? String == nil)
     }
 
     func testErrorToJsonFromProperties() {
@@ -102,9 +135,11 @@ class VCLErrorTest: XCTestCase {
             errorCode: ErrorMocks.ErrorCode,
             requestId: ErrorMocks.RequestId,
             message: ErrorMocks.Message,
-            statusCode : ErrorMocks.StatusCode
+            statusCode : ErrorMocks.StatusCode,
+            diagnostic: diagnostic
         )
         let errorDictionary = error.toDictionary()
+        let diagnosticDictionary = errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any?]
 
         assert(errorDictionary[VCLError.CodingKeys.KeyPayload] as? String == nil)
         assert(errorDictionary[VCLError.CodingKeys.KeyError] as? String == ErrorMocks.Error)
@@ -112,5 +147,10 @@ class VCLErrorTest: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyRequestId] as? String == ErrorMocks.RequestId)
         assert(errorDictionary[VCLError.CodingKeys.KeyMessage] as? String == ErrorMocks.Message)
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == diagnostic.nativeErrorType)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackFrames] as? [String] == diagnostic.nativeStackFrames)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackTop] as? String == diagnostic.nativeStackTop)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCause] as? String == diagnostic.nativeCause)
     }
 }

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -36,6 +36,7 @@ class VCLErrorTest: XCTestCase {
         assert(error.diagnostic?.nativeErrorType == VCLError.CodingKeys.ValuePayloadDiagnosticType)
         assert(error.diagnostic?.nativeStackFrames?.isEmpty == false)
         assert(error.diagnostic?.nativeStackTop == error.diagnostic?.nativeStackFrames?.first)
+        assert((error.diagnostic?.nativeStackFrames?.count ?? 0) <= VCLError.CodingKeys.MaxDiagnosticStackFrames)
     }
     
     func testErrorFromProperties() {
@@ -109,12 +110,12 @@ class VCLErrorTest: XCTestCase {
         assert(error.diagnostic?.nativeErrorType == "DummyError")
         assert(error.diagnostic?.nativeStackFrames?.isEmpty == false)
         assert(error.diagnostic?.nativeStackTop == error.diagnostic?.nativeStackFrames?.first)
+        assert((error.diagnostic?.nativeStackFrames?.count ?? 0) <= VCLError.CodingKeys.MaxDiagnosticStackFrames)
     }
 
     func testErrorToJsonFromPayload() {
         let error = VCLError(payload: ErrorMocks.Payload)
         let errorDictionary = error.toDictionary()
-        let diagnosticDictionary = errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any?]
 
         assert(errorDictionary[VCLError.CodingKeys.KeyPayload] as? String == ErrorMocks.Payload)
         assert(errorDictionary[VCLError.CodingKeys.KeyError] as? String == ErrorMocks.Error)
@@ -122,11 +123,7 @@ class VCLErrorTest: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyRequestId] as? String == ErrorMocks.RequestId)
         assert(errorDictionary[VCLError.CodingKeys.KeyMessage] as? String == ErrorMocks.Message)
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == VCLError.CodingKeys.ValuePayloadDiagnosticType)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackFrames] as? [String] != nil)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackTop] as? String != nil)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCause] as? String == nil)
+        assert(errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any] == nil)
     }
 
     func testErrorToJsonFromProperties() {
@@ -139,7 +136,6 @@ class VCLErrorTest: XCTestCase {
             diagnostic: diagnostic
         )
         let errorDictionary = error.toDictionary()
-        let diagnosticDictionary = errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any?]
 
         assert(errorDictionary[VCLError.CodingKeys.KeyPayload] as? String == nil)
         assert(errorDictionary[VCLError.CodingKeys.KeyError] as? String == ErrorMocks.Error)
@@ -147,10 +143,39 @@ class VCLErrorTest: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyRequestId] as? String == ErrorMocks.RequestId)
         assert(errorDictionary[VCLError.CodingKeys.KeyMessage] as? String == ErrorMocks.Message)
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
+        assert(errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any] == nil)
+    }
+
+    func testErrorToDiagnosticJsonFromPayload() {
+        let error = VCLError(payload: ErrorMocks.Payload)
+        let errorDictionary = error.toDiagnosticDictionary()
+        let diagnosticDictionary = errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any]
+
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == VCLError.CodingKeys.ValuePayloadDiagnosticType)
+        assert((diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackFrames] as? [String])?.count ?? 0 <= VCLError.CodingKeys.MaxDiagnosticStackFrames)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackTop] as? String != nil)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCause] as? String == nil)
+        assert(JSONSerialization.isValidJSONObject(errorDictionary))
+    }
+
+    func testErrorToDiagnosticJsonFromProperties() {
+        let error = VCLError(
+            error: ErrorMocks.Error,
+            errorCode: ErrorMocks.ErrorCode,
+            requestId: ErrorMocks.RequestId,
+            message: ErrorMocks.Message,
+            statusCode : ErrorMocks.StatusCode,
+            diagnostic: diagnostic
+        )
+        let errorDictionary = error.toDiagnosticDictionary()
+        let diagnosticDictionary = errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any]
+
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == diagnostic.nativeErrorType)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackFrames] as? [String] == diagnostic.nativeStackFrames)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackTop] as? String == diagnostic.nativeStackTop)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCause] as? String == diagnostic.nativeCause)
+        assert(JSONSerialization.isValidJSONObject(errorDictionary))
     }
 }

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -19,8 +19,7 @@ class VCLErrorTest: XCTestCase {
     private let diagnostic = VCLError.Diagnostic(
         nativeErrorType: "NativeErrorType",
         nativeCauseType: "NativeCauseType",
-        nativeCauseMessage: "NativeCauseMessage",
-        nativeCauseStackTop: "NativeCauseStackTop"
+        nativeCauseMessage: "NativeCauseMessage"
     )
     
     func testErrorFromPayload() {
@@ -36,7 +35,6 @@ class VCLErrorTest: XCTestCase {
         assert(error.diagnostic?.nativeErrorType == VCLError.CodingKeys.ValuePayloadDiagnosticType)
         assert(error.diagnostic?.nativeCauseType == nil)
         assert(error.diagnostic?.nativeCauseMessage == nil)
-        assert(error.diagnostic?.nativeCauseStackTop == nil)
     }
     
     func testErrorFromProperties() {
@@ -59,7 +57,6 @@ class VCLErrorTest: XCTestCase {
         assert(error.diagnostic?.nativeErrorType == diagnostic.nativeErrorType)
         assert(error.diagnostic?.nativeCauseType == diagnostic.nativeCauseType)
         assert(error.diagnostic?.nativeCauseMessage == diagnostic.nativeCauseMessage)
-        assert(error.diagnostic?.nativeCauseStackTop == diagnostic.nativeCauseStackTop)
     }
     
     func testErrorFromError1() {
@@ -83,7 +80,6 @@ class VCLErrorTest: XCTestCase {
         assert(error.diagnostic?.nativeErrorType == errorFromError.diagnostic?.nativeErrorType)
         assert(error.diagnostic?.nativeCauseType == errorFromError.diagnostic?.nativeCauseType)
         assert(error.diagnostic?.nativeCauseMessage == errorFromError.diagnostic?.nativeCauseMessage)
-        assert(error.diagnostic?.nativeCauseStackTop == errorFromError.diagnostic?.nativeCauseStackTop)
     }
     
     func testErrorFromError2() {
@@ -110,7 +106,6 @@ class VCLErrorTest: XCTestCase {
         assert(error.diagnostic?.nativeErrorType == "DummyError")
         assert(error.diagnostic?.nativeCauseType == nil)
         assert(error.diagnostic?.nativeCauseMessage == nil)
-        assert(error.diagnostic?.nativeCauseStackTop == nil)
     }
 
     func testErrorFromNonVCLErrorCapturesCauseMetadataWhenAvailable() {
@@ -125,7 +120,6 @@ class VCLErrorTest: XCTestCase {
         assert(error.diagnostic?.nativeErrorType == "NSError")
         assert(error.diagnostic?.nativeCauseType == "VCLError")
         assert(error.diagnostic?.nativeCauseMessage?.contains("underlying failure") == true)
-        assert(error.diagnostic?.nativeCauseStackTop != nil)
     }
 
     func testErrorToJsonFromPayload() {
@@ -170,7 +164,6 @@ class VCLErrorTest: XCTestCase {
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == VCLError.CodingKeys.ValuePayloadDiagnosticType)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseType] as? String == nil)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseMessage] as? String == nil)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseStackTop] as? String == nil)
         assert(JSONSerialization.isValidJSONObject(errorDictionary))
     }
 
@@ -190,7 +183,6 @@ class VCLErrorTest: XCTestCase {
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == diagnostic.nativeErrorType)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseType] as? String == diagnostic.nativeCauseType)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseMessage] as? String == diagnostic.nativeCauseMessage)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseStackTop] as? String == diagnostic.nativeCauseStackTop)
         assert(JSONSerialization.isValidJSONObject(errorDictionary))
     }
 }

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -15,12 +15,6 @@ class VCLErrorTest: XCTestCase {
     private struct DummyError: Error, CustomStringConvertible {
         let description: String
     }
-
-    private let diagnostic = VCLError.Diagnostic(
-        nativeErrorType: "NativeErrorType",
-        nativeCauseType: "NativeCauseType",
-        nativeCauseMessage: "NativeCauseMessage"
-    )
     
     func testErrorFromPayload() {
         let error = VCLError(payload: ErrorMocks.Payload)
@@ -31,20 +25,18 @@ class VCLErrorTest: XCTestCase {
         assert(error.requestId == ErrorMocks.RequestId)
         assert(error.message == ErrorMocks.Message)
         assert(error.statusCode == ErrorMocks.StatusCode)
-        assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
-        assert(error.diagnostic?.nativeErrorType == VCLError.CodingKeys.ValuePayloadDiagnosticType)
-        assert(error.diagnostic?.nativeCauseType == nil)
-        assert(error.diagnostic?.nativeCauseMessage == nil)
+        assert(error.cause == nil)
     }
     
     func testErrorFromProperties() {
+        let cause = DummyError(description: "manual cause")
         let error = VCLError(
             error: ErrorMocks.Error,
             errorCode: ErrorMocks.ErrorCode,
             requestId: ErrorMocks.RequestId,
             message: ErrorMocks.Message,
             statusCode: ErrorMocks.StatusCode,
-            diagnostic: diagnostic
+            cause: cause
         )
         
         assert(error.payload == nil)
@@ -53,20 +45,18 @@ class VCLErrorTest: XCTestCase {
         assert(error.requestId == ErrorMocks.RequestId)
         assert(error.message == ErrorMocks.Message)
         assert(error.statusCode == ErrorMocks.StatusCode)
-        assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
-        assert(error.diagnostic?.nativeErrorType == diagnostic.nativeErrorType)
-        assert(error.diagnostic?.nativeCauseType == diagnostic.nativeCauseType)
-        assert(error.diagnostic?.nativeCauseMessage == diagnostic.nativeCauseMessage)
+        assert((error.cause as? DummyError)?.description == cause.description)
     }
     
     func testErrorFromError1() {
+        let cause = DummyError(description: "wrapped cause")
         let error = VCLError(
             error: ErrorMocks.Error,
             errorCode: ErrorMocks.ErrorCode,
             requestId: ErrorMocks.RequestId,
             message: ErrorMocks.Message,
             statusCode: ErrorMocks.StatusCode,
-            diagnostic: diagnostic
+            cause: cause
         )
         let errorFromError = VCLError(error: error)
         
@@ -76,10 +66,7 @@ class VCLErrorTest: XCTestCase {
         assert(error.requestId == errorFromError.requestId)
         assert(error.message == errorFromError.message)
         assert(error.statusCode == errorFromError.statusCode)
-        assert(error.diagnostic?.nativePlatform == errorFromError.diagnostic?.nativePlatform)
-        assert(error.diagnostic?.nativeErrorType == errorFromError.diagnostic?.nativeErrorType)
-        assert(error.diagnostic?.nativeCauseType == errorFromError.diagnostic?.nativeCauseType)
-        assert(error.diagnostic?.nativeCauseMessage == errorFromError.diagnostic?.nativeCauseMessage)
+        assert((errorFromError.cause as? DummyError)?.description == cause.description)
     }
     
     func testErrorFromError2() {
@@ -102,13 +89,10 @@ class VCLErrorTest: XCTestCase {
         let error = VCLError(error: DummyError(description: "dummy failure"))
         
         assert(error.message == "dummy failure")
-        assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
-        assert(error.diagnostic?.nativeErrorType == "DummyError")
-        assert(error.diagnostic?.nativeCauseType == nil)
-        assert(error.diagnostic?.nativeCauseMessage == nil)
+        assert((error.cause as? DummyError)?.description == "dummy failure")
     }
 
-    func testErrorFromNonVCLErrorCapturesCauseMetadataWhenAvailable() {
+    func testErrorFromNonVCLErrorUsesWrappedErrorAsCause() {
         let underlyingError = VCLError(error: DummyError(description: "underlying failure"))
         let wrappedNSError = NSError(
             domain: "test",
@@ -117,9 +101,8 @@ class VCLErrorTest: XCTestCase {
         )
         let error = VCLError(error: wrappedNSError)
 
-        assert(error.diagnostic?.nativeErrorType == "NSError")
-        assert(error.diagnostic?.nativeCauseType == "VCLError")
-        assert(error.diagnostic?.nativeCauseMessage?.contains("underlying failure") == true)
+        assert((error.cause as NSError?)?.domain == "test")
+        assert((error.cause as NSError?)?.userInfo[NSUnderlyingErrorKey] as? VCLError != nil)
     }
 
     func testErrorToJsonFromPayload() {
@@ -132,17 +115,17 @@ class VCLErrorTest: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyRequestId] as? String == ErrorMocks.RequestId)
         assert(errorDictionary[VCLError.CodingKeys.KeyMessage] as? String == ErrorMocks.Message)
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
-        assert(errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any] == nil)
     }
 
     func testErrorToJsonFromProperties() {
+        let cause = DummyError(description: "manual cause")
         let error = VCLError(
             error: ErrorMocks.Error,
             errorCode: ErrorMocks.ErrorCode,
             requestId: ErrorMocks.RequestId,
             message: ErrorMocks.Message,
             statusCode : ErrorMocks.StatusCode,
-            diagnostic: diagnostic
+            cause: cause
         )
         let errorDictionary = error.toDictionary()
 
@@ -152,37 +135,5 @@ class VCLErrorTest: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyRequestId] as? String == ErrorMocks.RequestId)
         assert(errorDictionary[VCLError.CodingKeys.KeyMessage] as? String == ErrorMocks.Message)
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
-        assert(errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any] == nil)
-    }
-
-    func testErrorToDiagnosticJsonFromPayload() {
-        let error = VCLError(payload: ErrorMocks.Payload)
-        let errorDictionary = error.toDiagnosticDictionary()
-        let diagnosticDictionary = errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any]
-
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == VCLError.CodingKeys.ValuePayloadDiagnosticType)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseType] as? String == nil)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseMessage] as? String == nil)
-        assert(JSONSerialization.isValidJSONObject(errorDictionary))
-    }
-
-    func testErrorToDiagnosticJsonFromProperties() {
-        let error = VCLError(
-            error: ErrorMocks.Error,
-            errorCode: ErrorMocks.ErrorCode,
-            requestId: ErrorMocks.RequestId,
-            message: ErrorMocks.Message,
-            statusCode : ErrorMocks.StatusCode,
-            diagnostic: diagnostic
-        )
-        let errorDictionary = error.toDiagnosticDictionary()
-        let diagnosticDictionary = errorDictionary[VCLError.CodingKeys.KeyDiagnostic] as? [String: Any]
-
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == diagnostic.nativeErrorType)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseType] as? String == diagnostic.nativeCauseType)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseMessage] as? String == diagnostic.nativeCauseMessage)
-        assert(JSONSerialization.isValidJSONObject(errorDictionary))
     }
 }

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -18,9 +18,9 @@ class VCLErrorTest: XCTestCase {
 
     private let diagnostic = VCLError.Diagnostic(
         nativeErrorType: "NativeErrorType",
-        nativeStackFrames: ["frame 1", "frame 2"],
-        nativeStackTop: "frame 1",
-        nativeCause: "NativeCause"
+        nativeCauseType: "NativeCauseType",
+        nativeCauseMessage: "NativeCauseMessage",
+        nativeCauseStackTop: "NativeCauseStackTop"
     )
     
     func testErrorFromPayload() {
@@ -34,9 +34,9 @@ class VCLErrorTest: XCTestCase {
         assert(error.statusCode == ErrorMocks.StatusCode)
         assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
         assert(error.diagnostic?.nativeErrorType == VCLError.CodingKeys.ValuePayloadDiagnosticType)
-        assert(error.diagnostic?.nativeStackFrames?.isEmpty == false)
-        assert(error.diagnostic?.nativeStackTop == error.diagnostic?.nativeStackFrames?.first)
-        assert((error.diagnostic?.nativeStackFrames?.count ?? 0) <= VCLError.CodingKeys.MaxDiagnosticStackFrames)
+        assert(error.diagnostic?.nativeCauseType == nil)
+        assert(error.diagnostic?.nativeCauseMessage == nil)
+        assert(error.diagnostic?.nativeCauseStackTop == nil)
     }
     
     func testErrorFromProperties() {
@@ -57,9 +57,9 @@ class VCLErrorTest: XCTestCase {
         assert(error.statusCode == ErrorMocks.StatusCode)
         assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
         assert(error.diagnostic?.nativeErrorType == diagnostic.nativeErrorType)
-        assert(error.diagnostic?.nativeStackFrames == diagnostic.nativeStackFrames)
-        assert(error.diagnostic?.nativeStackTop == diagnostic.nativeStackTop)
-        assert(error.diagnostic?.nativeCause == diagnostic.nativeCause)
+        assert(error.diagnostic?.nativeCauseType == diagnostic.nativeCauseType)
+        assert(error.diagnostic?.nativeCauseMessage == diagnostic.nativeCauseMessage)
+        assert(error.diagnostic?.nativeCauseStackTop == diagnostic.nativeCauseStackTop)
     }
     
     func testErrorFromError1() {
@@ -81,9 +81,9 @@ class VCLErrorTest: XCTestCase {
         assert(error.statusCode == errorFromError.statusCode)
         assert(error.diagnostic?.nativePlatform == errorFromError.diagnostic?.nativePlatform)
         assert(error.diagnostic?.nativeErrorType == errorFromError.diagnostic?.nativeErrorType)
-        assert(error.diagnostic?.nativeStackFrames == errorFromError.diagnostic?.nativeStackFrames)
-        assert(error.diagnostic?.nativeStackTop == errorFromError.diagnostic?.nativeStackTop)
-        assert(error.diagnostic?.nativeCause == errorFromError.diagnostic?.nativeCause)
+        assert(error.diagnostic?.nativeCauseType == errorFromError.diagnostic?.nativeCauseType)
+        assert(error.diagnostic?.nativeCauseMessage == errorFromError.diagnostic?.nativeCauseMessage)
+        assert(error.diagnostic?.nativeCauseStackTop == errorFromError.diagnostic?.nativeCauseStackTop)
     }
     
     func testErrorFromError2() {
@@ -108,9 +108,24 @@ class VCLErrorTest: XCTestCase {
         assert(error.message == "dummy failure")
         assert(error.diagnostic?.nativePlatform == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
         assert(error.diagnostic?.nativeErrorType == "DummyError")
-        assert(error.diagnostic?.nativeStackFrames?.isEmpty == false)
-        assert(error.diagnostic?.nativeStackTop == error.diagnostic?.nativeStackFrames?.first)
-        assert((error.diagnostic?.nativeStackFrames?.count ?? 0) <= VCLError.CodingKeys.MaxDiagnosticStackFrames)
+        assert(error.diagnostic?.nativeCauseType == nil)
+        assert(error.diagnostic?.nativeCauseMessage == nil)
+        assert(error.diagnostic?.nativeCauseStackTop == nil)
+    }
+
+    func testErrorFromNonVCLErrorCapturesCauseMetadataWhenAvailable() {
+        let underlyingError = VCLError(error: DummyError(description: "underlying failure"))
+        let wrappedNSError = NSError(
+            domain: "test",
+            code: 1,
+            userInfo: [NSUnderlyingErrorKey: underlyingError]
+        )
+        let error = VCLError(error: wrappedNSError)
+
+        assert(error.diagnostic?.nativeErrorType == "NSError")
+        assert(error.diagnostic?.nativeCauseType == "VCLError")
+        assert(error.diagnostic?.nativeCauseMessage?.contains("underlying failure") == true)
+        assert(error.diagnostic?.nativeCauseStackTop != nil)
     }
 
     func testErrorToJsonFromPayload() {
@@ -153,9 +168,9 @@ class VCLErrorTest: XCTestCase {
 
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == VCLError.CodingKeys.ValuePayloadDiagnosticType)
-        assert((diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackFrames] as? [String])?.count ?? 0 <= VCLError.CodingKeys.MaxDiagnosticStackFrames)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackTop] as? String != nil)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCause] as? String == nil)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseType] as? String == nil)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseMessage] as? String == nil)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseStackTop] as? String == nil)
         assert(JSONSerialization.isValidJSONObject(errorDictionary))
     }
 
@@ -173,9 +188,9 @@ class VCLErrorTest: XCTestCase {
 
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativePlatform] as? String == VCLError.Diagnostic.CodingKeys.ValueNativePlatformIos)
         assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeErrorType] as? String == diagnostic.nativeErrorType)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackFrames] as? [String] == diagnostic.nativeStackFrames)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeStackTop] as? String == diagnostic.nativeStackTop)
-        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCause] as? String == diagnostic.nativeCause)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseType] as? String == diagnostic.nativeCauseType)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseMessage] as? String == diagnostic.nativeCauseMessage)
+        assert(diagnosticDictionary?[VCLError.Diagnostic.CodingKeys.KeyNativeCauseStackTop] as? String == diagnostic.nativeCauseStackTop)
         assert(JSONSerialization.isValidJSONObject(errorDictionary))
     }
 }

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -26,6 +26,7 @@ class VCLErrorTest: XCTestCase {
         assert(error.message == ErrorMocks.Message)
         assert(error.statusCode == ErrorMocks.StatusCode)
         assert(error.cause == nil)
+        assert(error.callStackSymbols?.isEmpty == false)
     }
     
     func testErrorFromProperties() {
@@ -46,6 +47,7 @@ class VCLErrorTest: XCTestCase {
         assert(error.message == ErrorMocks.Message)
         assert(error.statusCode == ErrorMocks.StatusCode)
         assert((error.cause as? DummyError)?.description == cause.description)
+        assert(error.callStackSymbols?.isEmpty == false)
     }
     
     func testErrorFromError1() {
@@ -67,6 +69,7 @@ class VCLErrorTest: XCTestCase {
         assert(error.message == errorFromError.message)
         assert(error.statusCode == errorFromError.statusCode)
         assert((errorFromError.cause as? DummyError)?.description == cause.description)
+        assert(error.callStackSymbols == errorFromError.callStackSymbols)
     }
     
     func testErrorFromError2() {
@@ -90,6 +93,7 @@ class VCLErrorTest: XCTestCase {
         
         assert(error.message == "dummy failure")
         assert((error.cause as? DummyError)?.description == "dummy failure")
+        assert(error.callStackSymbols?.isEmpty == false)
     }
 
     func testErrorFromNonVCLErrorUsesWrappedErrorAsCause() {


### PR DESCRIPTION
## Summary
- introduce to track `cause` model on `VCLError` and a stack trace using `callStackSymbols` for rn diagnostics
- keep `toDictionary()` stable-only and leave payload-derived `VCLError`s without a serialized cause
- pin the CI simulator destination to a concrete iOS runtime so the PR checks run reliably on GitHub Actions

## Testing
- `xcodebuild -project VCL/VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' -only-testing:VCLTests/VCLErrorTest test`
