### PR TITLE
[codex] chore: bump vcl version to 2.9.2

### DIFF
--- a/VCL/VCL.xcodeproj/project.pbxproj
+++ b/VCL/VCL.xcodeproj/project.pbxproj
@@ -2004,7 +2004,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 174;
+				CURRENT_PROJECT_VERSION = 175;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 7DDDGP43MJ;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2017,7 +2017,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.9.1;
+				MARKETING_VERSION = 2.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2034,7 +2034,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 174;
+				CURRENT_PROJECT_VERSION = 175;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 7DDDGP43MJ;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2047,7 +2047,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.9.1;
+				MARKETING_VERSION = 2.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## What changed
- bump `MARKETING_VERSION` from `2.9.1` to `2.9.2` for the VCL target
- bump `CURRENT_PROJECT_VERSION` from `174` to `175`
- prepare the next SDK publish from `main` via GitHub Actions

## Why
- the publish workflow derives the SDK release version from `VCL.xcodeproj`, so the project version needs to be advanced before triggering the next `2.9.2` GitHub Actions release flow

## Impact
- after this PR merges, `WalletIOS-SDK-Publish` can publish the `2.9.2` SDK from `main`
- this PR itself should only exercise the PR test workflow

## Validation
- no local build or tests run; this is a version-only project file change
- PR CI should run `WalletIOS-SDK-Tests`
