### PR TITLE
[codex] Expose native stack frames in error payload

### DIFF
--- a/VCL/VCL/api/entities/error/VCLError.swift
+++ b/VCL/VCL/api/entities/error/VCLError.swift
@@ -86,7 +86,8 @@ public struct VCLError: Error {
             CodingKeys.KeyErrorCode: errorCode,
             CodingKeys.KeyRequestId: requestId,
             CodingKeys.KeyMessage: message,
-            CodingKeys.KeyStatusCode: statusCode
+            CodingKeys.KeyStatusCode: statusCode,
+            CodingKeys.KeyCallStackSymbols: callStackSymbols
         ]
     }
     
@@ -97,5 +98,6 @@ public struct VCLError: Error {
         public static let KeyRequestId = "requestId"
         public static let KeyMessage = "message"
         public static let KeyStatusCode = "statusCode"
+        public static let KeyCallStackSymbols = "callStackSymbols"
     }
 }

--- a/VCL/VCLTests/entities/VCLErrorTest.swift
+++ b/VCL/VCLTests/entities/VCLErrorTest.swift
@@ -112,6 +112,7 @@ class VCLErrorTest: XCTestCase {
     func testErrorToJsonFromPayload() {
         let error = VCLError(payload: ErrorMocks.Payload)
         let errorDictionary = error.toDictionary()
+        let callStackSymbols = errorDictionary[VCLError.CodingKeys.KeyCallStackSymbols] as? [String]
 
         assert(errorDictionary[VCLError.CodingKeys.KeyPayload] as? String == ErrorMocks.Payload)
         assert(errorDictionary[VCLError.CodingKeys.KeyError] as? String == ErrorMocks.Error)
@@ -119,6 +120,7 @@ class VCLErrorTest: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyRequestId] as? String == ErrorMocks.RequestId)
         assert(errorDictionary[VCLError.CodingKeys.KeyMessage] as? String == ErrorMocks.Message)
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
+        assert(callStackSymbols?.isEmpty == false)
     }
 
     func testErrorToJsonFromProperties() {
@@ -132,6 +134,7 @@ class VCLErrorTest: XCTestCase {
             cause: cause
         )
         let errorDictionary = error.toDictionary()
+        let callStackSymbols = errorDictionary[VCLError.CodingKeys.KeyCallStackSymbols] as? [String]
 
         assert(errorDictionary[VCLError.CodingKeys.KeyPayload] as? String == nil)
         assert(errorDictionary[VCLError.CodingKeys.KeyError] as? String == ErrorMocks.Error)
@@ -139,5 +142,6 @@ class VCLErrorTest: XCTestCase {
         assert(errorDictionary[VCLError.CodingKeys.KeyRequestId] as? String == ErrorMocks.RequestId)
         assert(errorDictionary[VCLError.CodingKeys.KeyMessage] as? String == ErrorMocks.Message)
         assert(errorDictionary[VCLError.CodingKeys.KeyStatusCode] as? Int == ErrorMocks.StatusCode)
+        assert(callStackSymbols == error.callStackSymbols)
     }
 }


### PR DESCRIPTION
## Summary
- add a top-level `callStackSymbols` field to `VCLError.toDictionary()` backed by the captured native stack frames
- keep the richer `diagnostic` payload intact while exposing a succinct bridge-friendly alias for React Native consumers
- extend `VCLErrorTest` to cover the new serialized field for both captured and injected diagnostics

## Why
The iOS React Native bridge serializes `VCLError` through `toDictionary().toJsonString()`. Native stack frames were being captured, but they were not exposed in the top-level serialized payload that downstream bridge code reads.

## Impact
React Native consumers can now access iOS native stack frames from the serialized error payload without needing direct access to Swift-only internals.

## Validation
- `xcodebuild -project VCL/VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' test -only-testing:VCLTests/VCLErrorTest`
