### PR TITLE
[codex] Codify release branch policy

### DIFF
--- a/.github/releases/v2.9.3.md
+++ b/.github/releases/v2.9.3.md
@@ -1,0 +1,9 @@
+## Changes
+
+### [#174](https://github.com/velocitycareerlabs/WalletIOS/pull/174) Expose native stack frames in error payload
+- add a top-level `callStackSymbols` field to the serialized `VCLError` payload
+- keep the richer native diagnostic payload intact while exposing a simpler bridge-friendly alias
+- extend error serialization tests so downstream consumers can rely on the field being present when native stack frames are available
+
+## Backward incompatibilities
+- None expected.

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -62,6 +62,9 @@ jobs:
       # Git clone repository
       - name: Git clone repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ env.PAT_TOKEN }}
       # Select latest Xcode
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
@@ -80,11 +83,46 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
       # Get Version
       - name: Get Version
-        run: echo "FRAMEWORK_VERSION=$(cat VCL.xcodeproj/project.pbxproj | grep PRODUCT_BUNDLE_IDENTIFIER -B 1 | grep MARKETING_VERSION | cut -d'=' -f2 | uniq | sed -e 's/^[ \t]*//;s/;//')${{ env.RELEASE_TAG }}" >> $GITHUB_ENV
+        run: |
+          FRAMEWORK_VERSION=$(cat VCL.xcodeproj/project.pbxproj | grep PRODUCT_BUNDLE_IDENTIFIER -B 1 | grep MARKETING_VERSION | cut -d'=' -f2 | uniq | sed -e 's/^[ \t]*//;s/;//')${{ env.RELEASE_TAG }}
+          echo "FRAMEWORK_VERSION=${FRAMEWORK_VERSION}" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION=v${FRAMEWORK_VERSION}" >> "$GITHUB_ENV"
+          echo "RELEASE_NOTES_FILE=${GITHUB_WORKSPACE}/.github/releases/v${FRAMEWORK_VERSION}.md" >> "$GITHUB_ENV"
         working-directory: VCL
         env:
           # RELEASE_TAG: ${{ env.GLOBAL_ENV != 'prod' && format('{0}{1}', '-', env.RC_SUFFIX ) || '' }}
           RELEASE_TAG: ${{ '' }}
+      - name: Validate prod release context
+        if: env.GLOBAL_ENV == 'prod'
+        shell: bash
+        run: |
+          major_minor=$(printf '%s' "${FRAMEWORK_VERSION}" | cut -d. -f1,2)
+          patch_version=$(printf '%s' "${FRAMEWORK_VERSION}" | cut -d. -f3)
+          expected_release_branch="release/v${major_minor}"
+
+          if [ "${GITHUB_REF_NAME}" != "main" ] && [ "${GITHUB_REF_NAME}" != "${expected_release_branch}" ]; then
+            echo "Prod builds for ${FRAMEWORK_VERSION} may only run from main or ${expected_release_branch}."
+            exit 1
+          fi
+
+          if [ "$patch_version" != "0" ] && [ "${GITHUB_REF_NAME}" != "${expected_release_branch}" ]; then
+            echo "Patch release ${FRAMEWORK_VERSION} must run from ${expected_release_branch}."
+            exit 1
+          fi
+
+          if [ ! -f "${RELEASE_NOTES_FILE}" ]; then
+            echo "Missing release notes file: ${RELEASE_NOTES_FILE}"
+            exit 1
+          fi
+
+          grep -q '^## Changes$' "${RELEASE_NOTES_FILE}" || { echo "Release notes must include a '## Changes' section."; exit 1; }
+          grep -q '^## Backward incompatibilities$' "${RELEASE_NOTES_FILE}" || { echo "Release notes must include a '## Backward incompatibilities' section."; exit 1; }
+          grep -q '^### \[#' "${RELEASE_NOTES_FILE}" || { echo "Release notes must include at least one release entry heading."; exit 1; }
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${RELEASE_VERSION} already exists."
+            exit 1
+          fi
       # Clone Additional repos
       - name: Clone Additional repos
         run: |
@@ -104,10 +142,15 @@ jobs:
         run: |
            cp -r ../VCL/build/VCL.xcframework Frameworks/
            git add Frameworks/ && git commit -am "sdk ${{ env.FRAMEWORK_VERSION }}" && git push
-           git tag ${{ env.FRAMEWORK_VERSION }}
-           git push origin ${{ env.FRAMEWORK_VERSION }}
-           echo ${{ env.PAT_TOKEN }} | gh auth login --with-token
-           gh release create ${{ env.FRAMEWORK_VERSION }} --title "VCL-${{ env.FRAMEWORK_VERSION }}" ${{ env.RELEASE_ARG }}
         working-directory: VCL-Swift
-        env:
-          RELEASE_ARG: ${{ env.GLOBAL_ENV != 'prod' && format('{0}', '--prerelease' ) || format('{0}', '--latest') }}
+      - name: Create WalletIOS GitHub release
+        if: env.GLOBAL_ENV == 'prod'
+        shell: bash
+        run: |
+          git tag "${RELEASE_VERSION}" "${GITHUB_SHA}"
+          git push origin "${RELEASE_VERSION}"
+          echo "${PAT_TOKEN}" | gh auth login --with-token
+          gh release create "${RELEASE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${RELEASE_VERSION}" \
+            --notes-file "${RELEASE_NOTES_FILE}"

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - release/**
+      - release/v*
 jobs:
   tests-ios-sdk:
     runs-on: macos-15
@@ -14,6 +14,48 @@ jobs:
       # Git clone repository
       - name: Git clone repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate release notes for publish PRs
+        shell: bash
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+
+          version_diff=$(git diff --unified=0 "origin/${{ github.base_ref }}...HEAD" -- VCL/VCL.xcodeproj/project.pbxproj || true)
+          if ! printf '%s\n' "$version_diff" | grep -q '^[+-].*MARKETING_VERSION = '; then
+            echo "No SDK version change detected; skipping release notes validation."
+            exit 0
+          fi
+
+          framework_version=$(awk -F'= ' '/MARKETING_VERSION/ { gsub(/;/, "", $2); gsub(/[[:space:]]/, "", $2); print $2 }' VCL/VCL.xcodeproj/project.pbxproj | uniq | tail -n 1)
+          release_version="v${framework_version}"
+          release_notes_file=".github/releases/${release_version}.md"
+          major_minor=$(printf '%s' "$framework_version" | cut -d. -f1,2)
+          patch_version=$(printf '%s' "$framework_version" | cut -d. -f3)
+
+          if [ ! -f "$release_notes_file" ]; then
+            echo "$release_notes_file must exist for version $release_version."
+            exit 1
+          fi
+
+          if git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- "$release_notes_file"; then
+            echo "$release_notes_file must be added or updated in the same PR as the version bump."
+            exit 1
+          fi
+
+          grep -q '^## Changes$' "$release_notes_file" || { echo "$release_notes_file is missing a '## Changes' section."; exit 1; }
+          grep -q '^## Backward incompatibilities$' "$release_notes_file" || { echo "$release_notes_file is missing a '## Backward incompatibilities' section."; exit 1; }
+          grep -q '^### \[#' "$release_notes_file" || { echo "$release_notes_file must include at least one release entry heading."; exit 1; }
+
+          if [[ "${{ github.base_ref }}" == release/v* ]] && [ "${{ github.base_ref }}" != "release/v${major_minor}" ]; then
+            echo "Version ${framework_version} must target branch release/v${major_minor}, not ${{ github.base_ref }}."
+            exit 1
+          fi
+
+          if [ "${{ github.base_ref }}" = "main" ] && [ "$patch_version" != "0" ]; then
+            echo "Patch version ${framework_version} should not be bumped via a PR targeting main."
+            exit 1
+          fi
       # Select latest Xcode
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app || sudo xcode-select -s /Applications/Xcode_16.4.app"

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -19,9 +19,12 @@ jobs:
       - name: Validate release notes for publish PRs
         shell: bash
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          if ! git rev-parse --verify "${base_sha}^{commit}" >/dev/null 2>&1; then
+            git fetch origin "${base_sha}" --depth=1
+          fi
 
-          version_diff=$(git diff --unified=0 "origin/${{ github.base_ref }}...HEAD" -- VCL/VCL.xcodeproj/project.pbxproj || true)
+          version_diff=$(git diff --unified=0 "${base_sha}...HEAD" -- VCL/VCL.xcodeproj/project.pbxproj)
           if ! printf '%s\n' "$version_diff" | grep -q '^[+-].*MARKETING_VERSION = '; then
             echo "No SDK version change detected; skipping release notes validation."
             exit 0
@@ -38,7 +41,7 @@ jobs:
             exit 1
           fi
 
-          if git diff --quiet "origin/${{ github.base_ref }}...HEAD" -- "$release_notes_file"; then
+          if git diff --quiet "${base_sha}...HEAD" -- "$release_notes_file"; then
             echo "$release_notes_file must be added or updated in the same PR as the version bump."
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS
+
+- If you discover a likely bug, regression, or product gap that is not the central purpose of the current thread, explicitly ask whether I want you to create a GitHub issue for it.
+- See [RELEASING.md](RELEASING.md) for the WalletIOS release branching, tagging, and GitHub release-notes policy.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,38 @@
+# Releasing WalletIOS
+
+## Branch policy
+
+- `main` is for the next minor line under active development.
+- Each stabilizing minor line gets a long-lived branch named `release/vX.Y`.
+- Patch releases for that line are cut from the matching `release/vX.Y` branch.
+- Do not create one branch per patch version.
+
+Example:
+- Cut `release/v2.9` from `main` when `2.9.0` enters stabilization.
+- Bump `main` forward to `2.10.0` so next-minor work continues there.
+- Ship `v2.9.0`, `v2.9.1`, `v2.9.2` from the release commits on `release/v2.9`.
+
+## Release notes policy
+
+- Every version bump PR must add or update `.github/releases/vX.Y.Z.md`.
+- Release notes must include:
+  - `## Changes`
+  - at least one `### [#PR](...) ...` entry
+  - `## Backward incompatibilities`
+- The release notes file should describe the shipped SDK changes in the same style used for GitHub Releases.
+
+## Release PR policy
+
+- Tags must point to the release commit that was actually shipped.
+- Prod releases must only be run from:
+  - `release/vX.Y` for patch releases where `Z > 0`
+  - `main` or `release/vX.Y` for initial `vX.Y.0` releases
+
+## Recommended flow
+
+1. Cut `release/vX.Y` from `main`.
+2. Bump `main` to the next minor version.
+3. Prepare a release PR into `release/vX.Y` with the version bump and `.github/releases/vX.Y.Z.md`.
+4. Merge that PR and use the resulting release commit as the source of truth for the shipped tag.
+5. Run the prod release workflow from the release commit.
+6. Cherry-pick or forward-port fixes between `release/vX.Y` and `main` as needed.


### PR DESCRIPTION
## What changed
- codified the WalletIOS release process in `RELEASING.md`
- added `AGENTS.md` guidance pointing agents to the release policy
- moved release-note enforcement to versioned files under `.github/releases/vX.Y.Z.md`
- tightened PR validation so version bumps must bring the matching release notes file in the same PR
- tightened the publish workflow so prod GitHub Releases are created from WalletIOS itself and patch releases only run from the matching `release/vX.Y` branch

## Why
The release process had drifted away from the intended minor-line stabilization model. This change makes the expected branch, tag, and release-note flow explicit and enforces the critical parts in CI so the repo can stay aligned with the intended process.

## Impact
- maintainers now prepare release notes as part of the version bump PR itself
- patch releases are expected to come from the matching `release/vX.Y` branch
- prod releases tag and publish the source repo commit in WalletIOS GitHub Releases
- `main` remains available for next-minor work while a release line stabilizes on its own branch

## Validation
- parsed `.github/workflows/tests-ios-sdk.yml` with Ruby YAML
- parsed `.github/workflows/ios-sdk.yml` with Ruby YAML
- inspected the resulting release-note file and workflow diff locally