### PR TITLE
[codex] Add Swift error taxonomy baseline

### DIFF
--- a/VCL/VCL.xcodeproj/project.pbxproj
+++ b/VCL/VCL.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		283907FE272FE74D00AAB36E /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283907FD272FE74D00AAB36E /* Response.swift */; };
 		283AB6002DB0E980000907DB /* VCLAuthTokenDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283AB5FF2DB0E97E000907DB /* VCLAuthTokenDescriptorTests.swift */; };
 		283AB6032DB105AB000907DB /* VCLAuthTokenTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283AB6022DB105AA000907DB /* VCLAuthTokenTest.swift */; };
+		283AF0012DED000000000001 /* ErrorTaxonomyBackwardCompatibilityBaselineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283AF0002DED000000000001 /* ErrorTaxonomyBackwardCompatibilityBaselineTest.swift */; };
 		283BCF7029B921350023B219 /* VCLErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283BCF6F29B921350023B219 /* VCLErrorTest.swift */; };
 		283BCF7229B921BA0023B219 /* ErrorMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283BCF7129B921BA0023B219 /* ErrorMocks.swift */; };
 		283CBD9D2DE5A79C007528D1 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283CBD9C2DE5A799007528D1 /* Utils.swift */; };
@@ -375,6 +376,7 @@
 		283907FD272FE74D00AAB36E /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		283AB5FF2DB0E97E000907DB /* VCLAuthTokenDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCLAuthTokenDescriptorTests.swift; sourceTree = "<group>"; };
 		283AB6022DB105AA000907DB /* VCLAuthTokenTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCLAuthTokenTest.swift; sourceTree = "<group>"; };
+		283AF0002DED000000000001 /* ErrorTaxonomyBackwardCompatibilityBaselineTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTaxonomyBackwardCompatibilityBaselineTest.swift; sourceTree = "<group>"; };
 		283BCF6F29B921350023B219 /* VCLErrorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCLErrorTest.swift; sourceTree = "<group>"; };
 		283BCF7129B921BA0023B219 /* ErrorMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMocks.swift; sourceTree = "<group>"; };
 		283CBD9C2DE5A799007528D1 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -1133,6 +1135,14 @@
 			path = entities;
 			sourceTree = "<group>";
 		};
+		283AF0022DED000000000001 /* backwardscompatibility */ = {
+			isa = PBXGroup;
+			children = (
+				283AF0002DED000000000001 /* ErrorTaxonomyBackwardCompatibilityBaselineTest.swift */,
+			);
+			path = backwardscompatibility;
+			sourceTree = "<group>";
+		};
 		28905A7C2ACC1D4E0011B7FE /* local */ = {
 			isa = PBXGroup;
 			children = (
@@ -1186,6 +1196,7 @@
 		289A536D264D647200B84389 /* VCLTests */ = {
 			isa = PBXGroup;
 			children = (
+				283AF0022DED000000000001 /* backwardscompatibility */,
 				288405FA26C925F10030E967 /* entities */,
 				284BF89C270EDE8700030401 /* GlobalConfigTest.swift */,
 				289A5370264D647200B84389 /* Info.plist */,
@@ -1777,6 +1788,7 @@
 				284B89D12B2B32B7000E9776 /* CredentialsByDeepLinkVerifierTest.swift in Sources */,
 				28D62F312DF069B2009B9D8E /* DidDocumentMocks.swift in Sources */,
 				283BCF7029B921350023B219 /* VCLErrorTest.swift in Sources */,
+				283AF0012DED000000000001 /* ErrorTaxonomyBackwardCompatibilityBaselineTest.swift in Sources */,
 				283CBD9D2DE5A79C007528D1 /* Utils.swift in Sources */,
 				28BEC7212A0E6E37000DEC88 /* KeyServiceMocks.swift in Sources */,
 				281B64862C22CD3800413861 /* VCLOffersTest.swift in Sources */,

--- a/VCL/VCL/impl/VCLImpl.swift
+++ b/VCL/VCL/impl/VCLImpl.swift
@@ -34,6 +34,11 @@ public final class VCLImpl: VCL {
     
     private let initializationWatcher = InitializationWatcher(initAmount: VCLImpl.ModelsToInitializeAmount)
     private var profileServiceTypeVerifier: ProfileServiceTypeVerifier?
+    private let networkServiceFactory: () -> NetworkService
+
+    init(networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }) {
+        self.networkServiceFactory = networkServiceFactory
+    }
     
     public func initialize(
         initializationDescriptor: VCLInitializationDescriptor,
@@ -55,35 +60,58 @@ public final class VCLImpl: VCL {
     }
     
     private func initializeUseCases() throws {
-        authTokenUseCase = VclBlocksProvider.provideAuthTokenUseCase()
+        authTokenUseCase = VclBlocksProvider.provideAuthTokenUseCase(
+            networkServiceFactory: networkServiceFactory
+        )
         presentationRequestUseCase =
         try VclBlocksProvider.providePresentationRequestUseCase(
-            initializationDescriptor.cryptoServicesDescriptor
+            initializationDescriptor.cryptoServicesDescriptor,
+            networkServiceFactory: networkServiceFactory
         )
         presentationSubmissionUseCase = try VclBlocksProvider.providePresentationSubmissionUseCase(
-            initializationDescriptor.cryptoServicesDescriptor
+            initializationDescriptor.cryptoServicesDescriptor,
+            networkServiceFactory: networkServiceFactory
         )
-        exchangeProgressUseCase = VclBlocksProvider.provideExchangeProgressUseCase()
-        organizationsUseCase = VclBlocksProvider.provideOrganizationsUseCase()
+        exchangeProgressUseCase = VclBlocksProvider.provideExchangeProgressUseCase(
+            networkServiceFactory: networkServiceFactory
+        )
+        organizationsUseCase = VclBlocksProvider.provideOrganizationsUseCase(
+            networkServiceFactory: networkServiceFactory
+        )
         credentialManifestUseCase =
         try VclBlocksProvider.provideCredentialManifestUseCase(
-            initializationDescriptor.cryptoServicesDescriptor
+            initializationDescriptor.cryptoServicesDescriptor,
+            networkServiceFactory: networkServiceFactory
         )
         identificationSubmissionUseCase = try VclBlocksProvider.provideIdentificationSubmissionUseCase(
-            initializationDescriptor.cryptoServicesDescriptor
+            initializationDescriptor.cryptoServicesDescriptor,
+            networkServiceFactory: networkServiceFactory
         )
-        generateOffersUseCase = VclBlocksProvider.provideGenerateOffersUseCase()
+        generateOffersUseCase = VclBlocksProvider.provideGenerateOffersUseCase(
+            networkServiceFactory: networkServiceFactory
+        )
         finalizeOffersUseCase =
         try VclBlocksProvider.provideFinalizeOffersUseCase(
             initializationDescriptor.cryptoServicesDescriptor,
             credentialTypesModel,
-            initializationDescriptor.isDirectIssuerCheckOn
+            initializationDescriptor.isDirectIssuerCheckOn,
+            networkServiceFactory: networkServiceFactory
         )
         credentialTypesUIFormSchemaUseCase =
-        VclBlocksProvider.provideCredentialTypesUIFormSchemaUseCase()
-        verifiedProfileUseCase = VclBlocksProvider.provideVerifiedProfileUseCase()
-        jwtServiceUseCase = try VclBlocksProvider.provideJwtServiceUseCase(initializationDescriptor.cryptoServicesDescriptor)
-        keyServiceUseCase = try VclBlocksProvider.provideKeyServiceUseCase(initializationDescriptor.cryptoServicesDescriptor)
+        VclBlocksProvider.provideCredentialTypesUIFormSchemaUseCase(
+            networkServiceFactory: networkServiceFactory
+        )
+        verifiedProfileUseCase = VclBlocksProvider.provideVerifiedProfileUseCase(
+            networkServiceFactory: networkServiceFactory
+        )
+        jwtServiceUseCase = try VclBlocksProvider.provideJwtServiceUseCase(
+            initializationDescriptor.cryptoServicesDescriptor,
+            networkServiceFactory: networkServiceFactory
+        )
+        keyServiceUseCase = try VclBlocksProvider.provideKeyServiceUseCase(
+            initializationDescriptor.cryptoServicesDescriptor,
+            networkServiceFactory: networkServiceFactory
+        )
     }
     
     private func completionHandler(
@@ -112,9 +140,13 @@ public final class VCLImpl: VCL {
         successHandler: @escaping () -> Void,
         errorHandler: @escaping (VCLError) -> Void
     ) {
-        credentialTypesModel = VclBlocksProvider.provideCredentialTypesModel()
+        credentialTypesModel = VclBlocksProvider.provideCredentialTypesModel(
+            networkServiceFactory: networkServiceFactory
+        )
         
-        countriesModel = VclBlocksProvider.provideCountriesModel()
+        countriesModel = VclBlocksProvider.provideCountriesModel(
+            networkServiceFactory: networkServiceFactory
+        )
         
         countriesModel.initialize(cacheSequence: cacheSequence) { [weak self] result in
             do {
@@ -137,7 +169,10 @@ public final class VCLImpl: VCL {
                 }
                 else {
                     if let credentialTypes = self.credentialTypesModel.data {
-                        self.credentialTypeSchemasModel = VclBlocksProvider.provideCredentialTypeSchemasModel(credenctiialTypes: credentialTypes)
+                        self.credentialTypeSchemasModel = VclBlocksProvider.provideCredentialTypeSchemasModel(
+                            credenctiialTypes: credentialTypes,
+                            networkServiceFactory: self.networkServiceFactory
+                        )
                         self.credentialTypeSchemasModel?.initialize(cacheSequence: cacheSequence) { result in
                             do {
                                 _ = try result.get()

--- a/VCL/VCL/impl/VclBlocksProvider.swift
+++ b/VCL/VCL/impl/VclBlocksProvider.swift
@@ -14,7 +14,8 @@ class VclBlocksProvider {
     private init(){}
     
     static func chooseKeyService(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> VCLKeyService {
         switch (cryptoServicesDescriptor.cryptoServiceType) {
         case VCLCryptoServiceType.Local:
@@ -23,7 +24,7 @@ class VclBlocksProvider {
         case VCLCryptoServiceType.Remote:
             if let keyServiceUrls = cryptoServicesDescriptor.remoteCryptoServicesUrlsDescriptor?.keyServiceUrls {
                 return VCLKeyServiceRemoteImpl(
-                    NetworkServiceImpl(),
+                    networkServiceFactory(),
                     keyServiceUrls
                 )
             } else {
@@ -40,18 +41,22 @@ class VclBlocksProvider {
     }
     
     static func chooseJwtSignService(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> VCLJwtSignService {
         switch (cryptoServicesDescriptor.cryptoServiceType) {
         case VCLCryptoServiceType.Local:
             return VCLJwtSignServiceLocalImpl(
-                try chooseKeyService(cryptoServicesDescriptor)
+                try chooseKeyService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                )
             )
             
         case VCLCryptoServiceType.Remote:
             if let jwtSignServiceUrl = cryptoServicesDescriptor.remoteCryptoServicesUrlsDescriptor?.jwtServiceUrls.jwtSignServiceUrl {
                 return VCLJwtSignServiceRemoteImpl(
-                    NetworkServiceImpl(),
+                    networkServiceFactory(),
                     jwtSignServiceUrl
                 )
             } else {
@@ -68,7 +73,8 @@ class VclBlocksProvider {
     }
     
     static func chooseJwtVerifyService(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> VCLJwtVerifyService {
         switch (cryptoServicesDescriptor.cryptoServiceType) {
         case VCLCryptoServiceType.Local:
@@ -77,7 +83,7 @@ class VclBlocksProvider {
         case VCLCryptoServiceType.Remote:
             if let jwtVerifyServiceUrl = cryptoServicesDescriptor.remoteCryptoServicesUrlsDescriptor?.jwtServiceUrls.jwtVerifyServiceUrl {
                 return VCLJwtVerifyServiceRemoteImpl(
-                    NetworkServiceImpl(),
+                    networkServiceFactory(),
                     jwtVerifyServiceUrl
                 )
             } else {
@@ -93,11 +99,13 @@ class VclBlocksProvider {
         }
     }
     
-    static func provideCountriesModel() -> CountriesModel {
+    static func provideCountriesModel(
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
+    ) -> CountriesModel {
         return CountriesModelImpl(
             CountriesUseCaseImpl(
                 CountriesRepositoryImpl(
-                    NetworkServiceImpl(),
+                    networkServiceFactory(),
                     CacheServiceImpl()
                 ),
                 ExecutorImpl.instance
@@ -106,12 +114,13 @@ class VclBlocksProvider {
     }
     
     static func provideCredentialTypeSchemasModel(
-        credenctiialTypes: VCLCredentialTypes
+        credenctiialTypes: VCLCredentialTypes,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) -> CredentialTypeSchemasModel {
         return CredentialTypeSchemasModelImpl(
             CredentialTypeSchemasUseCaseImpl(
                 CredentialTypeSchemaRepositoryImpl(
-                    NetworkServiceImpl(),
+                    networkServiceFactory(),
                     CacheServiceImpl()
                 ),
                 credenctiialTypes,
@@ -121,11 +130,13 @@ class VclBlocksProvider {
         )
     }
     
-    static func provideCredentialTypesModel() -> CredentialTypesModel {
+    static func provideCredentialTypesModel(
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
+    ) -> CredentialTypesModel {
         return CredentialTypesModelImpl(
             CredentialTypesUseCaseImpl(
                 CredentialTypesRepositoryImpl(
-                    NetworkServiceImpl(),
+                    networkServiceFactory(),
                     CacheServiceImpl()
                 ),
                 ExecutorImpl.instance
@@ -134,18 +145,25 @@ class VclBlocksProvider {
     }
     
     static func providePresentationRequestUseCase(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> PresentationRequestUseCase {
         return PresentationRequestUseCaseImpl(
             PresentationRequestRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             ResolveDidDocumentRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             JwtServiceRepositoryImpl(
-                try chooseJwtSignService(cryptoServicesDescriptor),
-                try chooseJwtVerifyService(cryptoServicesDescriptor)
+                try chooseJwtSignService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                ),
+                try chooseJwtVerifyService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                )
             ),
             PresentationRequestByDeepLinkVerifierImpl(),
             ExecutorImpl.instance
@@ -153,42 +171,58 @@ class VclBlocksProvider {
     }
     
     static func providePresentationSubmissionUseCase(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> PresentationSubmissionUseCase {
         return PresentationSubmissionUseCaseImpl(
             PresentationSubmissionRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             JwtServiceRepositoryImpl(
-                try chooseJwtSignService(cryptoServicesDescriptor),
-                try chooseJwtVerifyService(cryptoServicesDescriptor)
+                try chooseJwtSignService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                ),
+                try chooseJwtVerifyService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                )
             ),
             ExecutorImpl.instance
         )
     }
     
-    static func provideOrganizationsUseCase() -> OrganizationsUseCase {
+    static func provideOrganizationsUseCase(
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
+    ) -> OrganizationsUseCase {
         return OrganizationsUseCaseImpl(
             OrganizationsRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             ExecutorImpl.instance
         )
     }
     
     static func provideCredentialManifestUseCase(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> CredentialManifestUseCase {
         return CredentialManifestUseCaseImpl(
             CredentialManifestRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             ResolveDidDocumentRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             JwtServiceRepositoryImpl(
-                try chooseJwtSignService(cryptoServicesDescriptor),
-                try chooseJwtVerifyService(cryptoServicesDescriptor)
+                try chooseJwtSignService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                ),
+                try chooseJwtVerifyService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                )
             ),
             CredentialManifestByDeepLinkVerifierImpl(),
             ExecutorImpl.instance
@@ -196,37 +230,48 @@ class VclBlocksProvider {
     }
     
     static func provideIdentificationSubmissionUseCase(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> IdentificationSubmissionUseCase {
         return IdentificationSubmissionUseCaseImpl(
             IdentificationSubmissionRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             JwtServiceRepositoryImpl(
-                try chooseJwtSignService(cryptoServicesDescriptor),
-                try chooseJwtVerifyService(cryptoServicesDescriptor)
+                try chooseJwtSignService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                ),
+                try chooseJwtVerifyService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                )
             ),
             ExecutorImpl.instance
         )
     }
     
-    static func provideExchangeProgressUseCase() -> ExchangeProgressUseCase {
+    static func provideExchangeProgressUseCase(
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
+    ) -> ExchangeProgressUseCase {
         return ExchangeProgressUseCaseImpl(
             ExchangeProgressRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             ExecutorImpl.instance
         )
     }
     
-    static func provideGenerateOffersUseCase() -> GenerateOffersUseCase {
+    static func provideGenerateOffersUseCase(
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
+    ) -> GenerateOffersUseCase {
         return GenerateOffersUseCaseImpl(
             GenerateOffersRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             OffersByDeepLinkVerifierImpl(
                 ResolveDidDocumentRepositoryImpl(
-                    NetworkServiceImpl()
+                    networkServiceFactory()
                 )
             ),
             ExecutorImpl.instance
@@ -236,81 +281,105 @@ class VclBlocksProvider {
     static func provideFinalizeOffersUseCase(
         _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
         _ credentialTypesModel: CredentialTypesModel,
-        _ isDirectIssuerCheckOn: Bool
+        _ isDirectIssuerCheckOn: Bool,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> FinalizeOffersUseCase {
         var credentialIssuerVerifier: CredentialIssuerVerifier = CredentialIssuerVerifierEmptyImpl()
         if (isDirectIssuerCheckOn) {
             credentialIssuerVerifier = CredentialIssuerVerifierImpl(
                 credentialTypesModel,
                 CredentialSubjectContextRepositoryImpl(
-                    NetworkServiceImpl()
+                    networkServiceFactory()
                 )
             )
         }
         return FinalizeOffersUseCaseImpl(
             FinalizeOffersRepositoryImpl(
-                NetworkServiceImpl()),
+                networkServiceFactory()),
             JwtServiceRepositoryImpl(
-                try chooseJwtSignService(cryptoServicesDescriptor),
-                try chooseJwtVerifyService(cryptoServicesDescriptor)
+                try chooseJwtSignService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                ),
+                try chooseJwtVerifyService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                )
             ),
             credentialIssuerVerifier,
             CredentialDidVerifierImpl(),
             CredentialsByDeepLinkVerifierImpl(
                 ResolveDidDocumentRepositoryImpl(
-                    NetworkServiceImpl()
+                    networkServiceFactory()
                 )
             ),
             ExecutorImpl.instance
         )
     }
     
-    static func provideAuthTokenUseCase() -> AuthTokenUseCase {
+    static func provideAuthTokenUseCase(
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
+    ) -> AuthTokenUseCase {
         return AuthTokenUseCaseImpl(
             AuthTokenRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             ExecutorImpl.instance
         )
     }
     
-    static func provideCredentialTypesUIFormSchemaUseCase() -> CredentialTypesUIFormSchemaUseCase {
+    static func provideCredentialTypesUIFormSchemaUseCase(
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
+    ) -> CredentialTypesUIFormSchemaUseCase {
         return CredentialTypesUIFormSchemaUseCaseImpl(
             CredentialTypesUIFormSchemaRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             ExecutorImpl.instance,
             DispatcherImpl()
         )
     }
     
-    static func provideVerifiedProfileUseCase() -> VerifiedProfileUseCase {
+    static func provideVerifiedProfileUseCase(
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
+    ) -> VerifiedProfileUseCase {
         return VerifiedProfileUseCaseImpl(
             VerifiedProfileRepositoryImpl(
-                NetworkServiceImpl()
+                networkServiceFactory()
             ),
             ExecutorImpl.instance
         )
     }
     
     static func provideJwtServiceUseCase(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> JwtServiceUseCase {
         return JwtServiceUseCaseImpl(
             JwtServiceRepositoryImpl(
-                try chooseJwtSignService(cryptoServicesDescriptor),
-                try chooseJwtVerifyService(cryptoServicesDescriptor)
+                try chooseJwtSignService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                ),
+                try chooseJwtVerifyService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                )
             ),
             ExecutorImpl.instance
         )
     }
     
     static func provideKeyServiceUseCase(
-        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+        _ cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+        networkServiceFactory: @escaping () -> NetworkService = { NetworkServiceImpl() }
     ) throws -> KeyServiceUseCase {
         return KeyServiceUseCaseImpl(
             KeyServiceRepositoryImpl(
-                try chooseKeyService(cryptoServicesDescriptor)
+                try chooseKeyService(
+                    cryptoServicesDescriptor,
+                    networkServiceFactory: networkServiceFactory
+                )
             ),
             ExecutorImpl.instance
         )

--- a/VCL/VCL/impl/data/repositories/PresentationRequestRepositoryImpl.swift
+++ b/VCL/VCL/impl/data/repositories/PresentationRequestRepositoryImpl.swift
@@ -40,8 +40,7 @@ final class PresentationRequestRepositoryImpl: PresentationRequestRepository {
                     }
                 }
         } else {
-            completionBlock(.failure(VCLError(message: "credentialManifestDescriptor.endpoint = null")))
+            completionBlock(.failure(VCLError(message: "presentationRequestDescriptor.endpoint = null")))
         }
     }
 }
-

--- a/VCL/VCL/impl/data/usecases/CredentialManifestUseCaseImpl.swift
+++ b/VCL/VCL/impl/data/usecases/CredentialManifestUseCaseImpl.swift
@@ -63,7 +63,7 @@ final class CredentialManifestUseCaseImpl: CredentialManifestUseCase {
                                 )
                             } else {
                                 self?.onError(
-                                    VCLError(error: "public jwk not found for kid: \(credentialManifest.jwt.kid ?? "")"),
+                                    VCLError(message: "public jwk not found for kid: \(credentialManifest.jwt.kid ?? "")"),
                                     completionBlock
                                 )
                             }

--- a/VCL/VCL/impl/data/usecases/PresentationRequestUseCaseImpl.swift
+++ b/VCL/VCL/impl/data/usecases/PresentationRequestUseCaseImpl.swift
@@ -63,7 +63,7 @@ final class PresentationRequestUseCaseImpl: PresentationRequestUseCase {
                                 )
                             } else {
                                 self?.onError(
-                                    VCLError(error: "public jwk not found for kid: \(presentationRequest.jwt.kid ?? "")"),
+                                    VCLError(message: "public jwk not found for kid: \(presentationRequest.jwt.kid ?? "")"),
                                     completionBlock
                                 )
                             }

--- a/VCL/VCLTests/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.swift
+++ b/VCL/VCLTests/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.swift
@@ -527,7 +527,7 @@ private extension ErrorTaxonomyBackwardCompatibilityBaselineTest.EntryPoint {
         case .issuing:
             return "credentialManifestDescriptor.endpoint = null"
         case .presentation:
-            return "credentialManifestDescriptor.endpoint = null"
+            return "presentationRequestDescriptor.endpoint = null"
         }
     }
     

--- a/VCL/VCLTests/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.swift
+++ b/VCL/VCLTests/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.swift
@@ -1,0 +1,773 @@
+//
+//  ErrorTaxonomyBackwardCompatibilityBaselineTest.swift
+//  VCLTests
+//
+//  Copyright 2022 Velocity Career Labs inc.
+//  SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+import XCTest
+@testable import VCL
+
+final class ErrorTaxonomyBackwardCompatibilityBaselineTest: XCTestCase {
+    func testMalformedLinksAndMissingRequiredParamsReturnSdkError() {
+        entryPoints.forEach { entryPoint in
+            let missingDidDeepLink = VCLDeepLink(value: "velocity-network://\(entryPoint.schemePath)")
+            
+            [VCLDeepLink(value: "not a url"), missingDidDeepLink].forEach { deepLink in
+                let error = getEntryPointError(entryPoint, deepLink: deepLink)
+                
+                XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+                XCTAssertTrue(error.message?.contains("did was not found") == true)
+            }
+        }
+    }
+    
+    func testUnsupportedSchemeWithKnownQueryParamsReturnsNullEndpointSdkError() {
+        entryPoints.forEach { entryPoint in
+            let deepLink = VCLDeepLink(
+                value: "https://example.com/\(entryPoint.schemePath)?\(entryPoint.didParam)=did:example:entity"
+            )
+            let error = getEntryPointError(entryPoint, deepLink: deepLink)
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.message, entryPoint.endpointNullMessage)
+        }
+    }
+    
+    func testUndecodableQueryParamsAreAcceptedUntilSdkEntryPoint() {
+        [
+            VCLDeepLink(value: "velocity-network://issue?request_uri=%"),
+            VCLDeepLink(value: "velocity-network://inspect?request_uri=%")
+        ].enumerated().forEach { index, deepLink in
+            let error = getEntryPointError(entryPoints[index], deepLink: deepLink)
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertTrue(error.message?.contains("did was not found") == true)
+        }
+    }
+    
+    func testMissingRequestUriProducesEndpointNullSdkErrors() {
+        entryPoints.forEach { entryPoint in
+            let deepLink = VCLDeepLink(
+                value: "velocity-network://\(entryPoint.schemePath)?\(entryPoint.didParam)=did:example:entity"
+            )
+            let error = getEntryPointError(entryPoint, deepLink: deepLink)
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.message, entryPoint.endpointNullMessage)
+        }
+    }
+    
+    func testMalformedAndDisallowedRequestUriValuesReachTransportAsRawEndpointText() {
+        entryPoints.forEach { entryPoint in
+            let malformedRequestUriDeepLink = VCLDeepLink(
+                value: "velocity-network://\(entryPoint.schemePath)?request_uri=not-a-url" +
+                    "&\(entryPoint.didParam)=did:example:entity"
+            )
+            let disallowedSchemeDeepLink = VCLDeepLink(
+                value: "velocity-network://\(entryPoint.schemePath)?" +
+                    "request_uri=ftp%3A%2F%2Fexample.com%2Frequest" +
+                    "&\(entryPoint.didParam)=did:example:entity"
+            )
+            let malformedRequestUri = getEntryPointError(entryPoint, deepLink: malformedRequestUriDeepLink)
+            let disallowedSchemeRequestUri = getEntryPointError(entryPoint, deepLink: disallowedSchemeDeepLink)
+            
+            XCTAssertEqual(malformedRequestUri.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertTrue(
+                malformedRequestUri.message?.contains("NSURLErrorDomain Code=-1002") == true,
+                "message: \(malformedRequestUri.message ?? "nil")"
+            )
+            XCTAssertEqual(disallowedSchemeRequestUri.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertTrue(
+                disallowedSchemeRequestUri.message?.contains("NSURLErrorDomain Code=-1002") == true,
+                "message: \(disallowedSchemeRequestUri.message ?? "nil")"
+            )
+        }
+    }
+    
+    func testTransportFailureReturnsSdkErrorWithNetworkStatusOnly() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(requestFailure: BaselineNetworkError(message: "offline"))
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.statusCode, VCLStatusCode.NetworkError.rawValue)
+            XCTAssertTrue(error.message?.contains("offline") == true)
+        }
+    }
+    
+    func testRequestEndpoint401And403PreserveHttpStatusAndPayloadErrorCode() {
+        entryPoints.forEach { entryPoint in
+            [401, 403].forEach { statusCode in
+                let error = getEntryPointError(
+                    entryPoint,
+                    router: defaultRouter(entryPoint).copy(
+                        requestPayload: ErrorMocks.Payload,
+                        requestStatusCode: statusCode,
+                        requestContentType: Request.ContentType.ApplicationJson.rawValue
+                    )
+                )
+                
+                XCTAssertEqual(error.errorCode, ErrorMocks.ErrorCode)
+                XCTAssertEqual(error.requestId, ErrorMocks.RequestId)
+                XCTAssertEqual(error.message, ErrorMocks.Message)
+                XCTAssertEqual(error.statusCode, ErrorMocks.StatusCode)
+            }
+        }
+    }
+    
+    func testRequestEndpointRejectionsPreserveHttpStatusWhenPayloadHasNoStatusCode() {
+        var payloadWithoutStatusCode = ErrorMocks.Payload.toDictionary()!
+        payloadWithoutStatusCode.removeValue(forKey: VCLError.CodingKeys.KeyStatusCode)
+        
+        entryPoints.forEach { entryPoint in
+            [400, 404, 409, 410, 422, 500, 502].forEach { statusCode in
+                let error = getEntryPointError(
+                    entryPoint,
+                    router: defaultRouter(entryPoint).copy(
+                        requestPayload: payloadWithoutStatusCode.toJsonString()!,
+                        requestStatusCode: statusCode,
+                        requestContentType: Request.ContentType.ApplicationJson.rawValue
+                    )
+                )
+                
+                XCTAssertEqual(error.errorCode, ErrorMocks.ErrorCode)
+                XCTAssertEqual(error.statusCode, statusCode)
+            }
+        }
+    }
+    
+    func testPlainTextRequestEndpointRejectionsDefaultToSdkErrorWithHttpStatusAndPayloadMessage() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(
+                    requestPayload: "plain text failure",
+                    requestStatusCode: 500,
+                    requestContentType: "text/plain"
+                )
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.statusCode, 500)
+            XCTAssertEqual(error.message, "plain text failure")
+            XCTAssertNil(error.payload)
+        }
+    }
+    
+    func testJsonRequestEndpointRejectionsWithoutErrorCodeDefaultToSdkError() {
+        var payloadWithoutErrorCode = ErrorMocks.Payload.toDictionary()!
+        payloadWithoutErrorCode.removeValue(forKey: VCLError.CodingKeys.KeyErrorCode)
+        
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(
+                    requestPayload: payloadWithoutErrorCode.toJsonString()!,
+                    requestStatusCode: 422,
+                    requestContentType: Request.ContentType.ApplicationJson.rawValue
+                )
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.requestId, ErrorMocks.RequestId)
+            XCTAssertEqual(error.message, ErrorMocks.Message)
+            XCTAssertEqual(error.statusCode, ErrorMocks.StatusCode)
+        }
+    }
+    
+    func testEmptyRequestEndpointResponseReturnsSdkError() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(requestPayload: "")
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+        }
+    }
+    
+    func testMalformedRequestEndpointResponseReturnsSdkError() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(requestPayload: "not json")
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+        }
+    }
+    
+    func testMissingExpectedRequestFieldsReturnSdkErrorAfterEmptyJwtIsDecoded() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(requestPayload: "{}")
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+        }
+    }
+    
+    func testDidResolutionNetworkFailurePropagatesSdkErrorAndStatusFromNetwork() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(
+                    didDocumentPayload: #"{"message":"resolve failed","errorCode":"sdk_error"}"#,
+                    didDocumentStatusCode: 404,
+                    didDocumentContentType: Request.ContentType.ApplicationJson.rawValue
+                )
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.statusCode, 404)
+            XCTAssertEqual(error.message, "resolve failed")
+        }
+    }
+    
+    func testInvalidDidDocumentShapeReturnsSdkErrorAtRequestValidation() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(didDocumentPayload: "not json")
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.message, "Failed to parse not json")
+        }
+    }
+    
+    func testMissingDidDocumentVerificationMaterialReturnsSdkError() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(didDocumentPayload: "{}")
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertTrue(
+                error.error?.contains("public jwk not found for kid") == true,
+                "error: \(error.error ?? "nil"), message: \(error.message ?? "nil")"
+            )
+        }
+    }
+    
+    func testVerifiedProfileLookupFailurePropagatesNetworkErrorDetails() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(
+                    verifiedProfilePayload: #"{"message":"profile missing","errorCode":"sdk_error"}"#,
+                    verifiedProfileStatusCode: 404,
+                    verifiedProfileContentType: Request.ContentType.ApplicationJson.rawValue
+                )
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.statusCode, 404)
+            XCTAssertEqual(error.message, "profile missing")
+        }
+    }
+    
+    func testEmptyVerifiedProfileFailsServiceTypeVerification() {
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(verifiedProfilePayload: "{}")
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.statusCode, VCLStatusCode.VerificationError.rawValue)
+            XCTAssertTrue(error.message?.contains("Wrong service type") == true)
+        }
+    }
+    
+    func testWrongIssuerOrVerifierServiceTypeReturnsSdkErrorWithVerificationStatus() {
+        entryPoints.forEach { entryPoint in
+            let wrongServiceProfile = entryPoint == .issuing
+                ? VerifiedProfileMocks.VerifiedProfileInspectorJsonStr
+                : VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1
+            let error = getEntryPointError(
+                entryPoint,
+                router: defaultRouter(entryPoint).copy(verifiedProfilePayload: wrongServiceProfile)
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.statusCode, VCLStatusCode.VerificationError.rawValue)
+            XCTAssertTrue(error.message?.contains("Wrong service type") == true)
+        }
+    }
+    
+    func testDuplicateQueryParamsUseLastDidValueAtSdkEntryPoint() {
+        entryPoints.forEach { entryPoint in
+            let router = defaultRouter(entryPoint)
+            let vcl = initializedVcl(router: router)
+            let deepLink = VCLDeepLink(
+                value: "velocity-network://\(entryPoint.schemePath)?request_uri=\(entryPoint.encodedRequestUri)" +
+                    "&\(entryPoint.didParam)=did:example:first&\(entryPoint.didParam)=\(entryPoint.lastDid)"
+            )
+            let error = entryPoint == .issuing
+                ? awaitCredentialManifestError(vcl: vcl, descriptor: credentialManifestDescriptor(deepLink: deepLink))
+                : awaitPresentationRequestError(vcl: vcl, descriptor: presentationDescriptor(deepLink: deepLink))
+            
+            XCTAssertEqual(error.errorCode, entryPoint.mismatchErrorCode)
+            XCTAssertTrue(router.requestedEndpoints.contains { $0.contains(entryPoint.lastDid) })
+        }
+    }
+    
+    func testMalformedDidSyntaxIsAcceptedUntilRequestValidation() {
+        entryPoints.forEach { entryPoint in
+            let deepLink = VCLDeepLink(
+                value: "velocity-network://\(entryPoint.schemePath)?request_uri=\(entryPoint.encodedRequestUri)" +
+                    "&\(entryPoint.didParam)=not-a-did"
+            )
+            let error = getEntryPointError(entryPoint, deepLink: deepLink)
+            
+            XCTAssertEqual(error.errorCode, entryPoint.mismatchErrorCode)
+        }
+    }
+    
+    func testRequestValidationFailuresUseLegacyMismatchErrorCodes() {
+        entryPoints.forEach { entryPoint in
+            let deepLink = VCLDeepLink(
+                value: "velocity-network://\(entryPoint.schemePath)?request_uri=\(entryPoint.encodedRequestUri)" +
+                    "&\(entryPoint.didParam)=did:example:wrong"
+            )
+            let error = getEntryPointError(entryPoint, deepLink: deepLink)
+            
+            XCTAssertEqual(error.errorCode, entryPoint.mismatchErrorCode)
+        }
+    }
+    
+    func testJwtVerificationFailurePropagatesSdkErrorFromInjectedJwtService() {
+        let expectedError = VCLError(
+            errorCode: VCLErrorCode.SdkError.rawValue,
+            message: "jwt signature verification failed"
+        )
+        
+        entryPoints.forEach { entryPoint in
+            let error = getEntryPointError(
+                entryPoint,
+                jwtVerificationResult: .failure(expectedError)
+            )
+            
+            XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
+            XCTAssertEqual(error.message, "jwt signature verification failed")
+        }
+    }
+    
+    fileprivate enum EntryPoint {
+        case issuing
+        case presentation
+    }
+    
+    private let entryPoints: [EntryPoint] = [.issuing, .presentation]
+    
+    private func defaultRouter(_ entryPoint: EntryPoint) -> BaselineHttpRouter {
+        switch entryPoint {
+        case .issuing:
+            return BaselineHttpRouter()
+        case .presentation:
+            return BaselineHttpRouter(
+                verifiedProfilePayload: VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
+                requestPayload: PresentationRequestMocks.EncodedPresentationRequestResponse
+            )
+        }
+    }
+    
+    private func getEntryPointError(
+        _ entryPoint: EntryPoint,
+        deepLink: VCLDeepLink? = nil,
+        router: BaselineHttpRouter? = nil,
+        jwtVerificationResult: VCLResult<Bool> = .success(true)
+    ) -> VCLError {
+        switch entryPoint {
+        case .issuing:
+            return getCredentialManifestError(
+                deepLink: deepLink ?? entryPoint.defaultDeepLink,
+                router: router ?? defaultRouter(entryPoint),
+                jwtVerificationResult: jwtVerificationResult
+            )
+        case .presentation:
+            return getPresentationRequestError(
+                deepLink: deepLink ?? entryPoint.defaultDeepLink,
+                router: router ?? defaultRouter(entryPoint),
+                jwtVerificationResult: jwtVerificationResult
+            )
+        }
+    }
+    
+    private func getCredentialManifestError(
+        deepLink: VCLDeepLink,
+        router: BaselineHttpRouter,
+        jwtVerificationResult: VCLResult<Bool>
+    ) -> VCLError {
+        let vcl = initializedVcl(router: router, jwtVerificationResult: jwtVerificationResult)
+        return awaitCredentialManifestError(vcl: vcl, descriptor: credentialManifestDescriptor(deepLink: deepLink))
+    }
+    
+    private func getPresentationRequestError(
+        deepLink: VCLDeepLink,
+        router: BaselineHttpRouter,
+        jwtVerificationResult: VCLResult<Bool>
+    ) -> VCLError {
+        let vcl = initializedVcl(router: router, jwtVerificationResult: jwtVerificationResult)
+        return awaitPresentationRequestError(vcl: vcl, descriptor: presentationDescriptor(deepLink: deepLink))
+    }
+    
+    private func initializedVcl(
+        router: BaselineHttpRouter,
+        jwtVerificationResult: VCLResult<Bool> = .success(true)
+    ) -> VCLImpl {
+        let vcl = VCLImpl(networkServiceFactory: { router })
+        let expectation = expectation(description: "VCL initialized")
+        var initError: VCLError?
+        vcl.initialize(
+            initializationDescriptor: VCLInitializationDescriptor(
+                cacheSequence: Self.nextCacheSequence(),
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor(
+                    cryptoServiceType: VCLCryptoServiceType.Injected,
+                    injectedCryptoServicesDescriptor: VCLInjectedCryptoServicesDescriptor(
+                        keyService: VCLKeyServiceMock(),
+                        jwtSignService: VCLJwtSignServiceMock(),
+                        jwtVerifyService: FixedJwtVerifyService(result: jwtVerificationResult)
+                    )
+                )
+            ),
+            successHandler: { expectation.fulfill() },
+            errorHandler: {
+                initError = $0
+                expectation.fulfill()
+            }
+        )
+        wait(for: [expectation], timeout: 5)
+        XCTAssertNil(initError, "VCL initialization failed: \(String(describing: initError?.toDictionary()))")
+        return vcl
+    }
+    
+    private func awaitCredentialManifestError(
+        vcl: VCLImpl,
+        descriptor: VCLCredentialManifestDescriptorByDeepLink
+    ) -> VCLError {
+        let expectation = expectation(description: "credential manifest failure")
+        var result: VCLError?
+        vcl.getCredentialManifest(
+            credentialManifestDescriptor: descriptor,
+            successHandler: { manifest in
+                XCTFail("Credential manifest failure expected: \(manifest)")
+                expectation.fulfill()
+            },
+            errorHandler: {
+                result = $0
+                expectation.fulfill()
+            }
+        )
+        wait(for: [expectation], timeout: 5)
+        return result ?? VCLError(message: "getCredentialManifest did not invoke errorHandler")
+    }
+    
+    private func awaitPresentationRequestError(
+        vcl: VCLImpl,
+        descriptor: VCLPresentationRequestDescriptor
+    ) -> VCLError {
+        let expectation = expectation(description: "presentation request failure")
+        var result: VCLError?
+        vcl.getPresentationRequest(
+            presentationRequestDescriptor: descriptor,
+            successHandler: { presentationRequest in
+                XCTFail("Presentation request failure expected: \(presentationRequest)")
+                expectation.fulfill()
+            },
+            errorHandler: {
+                result = $0
+                expectation.fulfill()
+            }
+        )
+        wait(for: [expectation], timeout: 5)
+        return result ?? VCLError(message: "getPresentationRequest did not invoke errorHandler")
+    }
+    
+    private func credentialManifestDescriptor(deepLink: VCLDeepLink) -> VCLCredentialManifestDescriptorByDeepLink {
+        VCLCredentialManifestDescriptorByDeepLink(
+            deepLink: deepLink,
+            didJwk: DidJwkMocks.DidJwk
+        )
+    }
+    
+    private func presentationDescriptor(deepLink: VCLDeepLink) -> VCLPresentationRequestDescriptor {
+        VCLPresentationRequestDescriptor(
+            deepLink: deepLink,
+            didJwk: DidJwkMocks.DidJwk
+        )
+    }
+    
+    private static var cacheSequence = 1000
+    private static func nextCacheSequence() -> Int {
+        cacheSequence += 1
+        return cacheSequence
+    }
+}
+
+private extension ErrorTaxonomyBackwardCompatibilityBaselineTest.EntryPoint {
+    var defaultDeepLink: VCLDeepLink {
+        switch self {
+        case .issuing:
+            return DeepLinkMocks.CredentialManifestDeepLinkDevNet
+        case .presentation:
+            return DeepLinkMocks.PresentationRequestDeepLinkDevNet
+        }
+    }
+    
+    var endpointNullMessage: String {
+        switch self {
+        case .issuing:
+            return "credentialManifestDescriptor.endpoint = null"
+        case .presentation:
+            return "credentialManifestDescriptor.endpoint = null"
+        }
+    }
+    
+    var mismatchErrorCode: String {
+        switch self {
+        case .issuing:
+            return VCLErrorCode.MismatchedRequestIssuerDid.rawValue
+        case .presentation:
+            return VCLErrorCode.MismatchedPresentationRequestInspectorDid.rawValue
+        }
+    }
+    
+    var didParam: String {
+        switch self {
+        case .issuing:
+            return "issuerDid"
+        case .presentation:
+            return "inspectorDid"
+        }
+    }
+    
+    var schemePath: String {
+        switch self {
+        case .issuing:
+            return "issue"
+        case .presentation:
+            return "inspect"
+        }
+    }
+    
+    var encodedRequestUri: String {
+        switch self {
+        case .issuing:
+            return DeepLinkMocks.CredentialManifestRequestUriStr
+        case .presentation:
+            return DeepLinkMocks.PresentationRequestRequestUriStr
+        }
+    }
+    
+    var lastDid: String {
+        "did:example:last"
+    }
+}
+
+private final class FixedJwtVerifyService: VCLJwtVerifyService {
+    private let result: VCLResult<Bool>
+    
+    init(result: VCLResult<Bool>) {
+        self.result = result
+    }
+    
+    func verify(
+        jwt: VCLJwt,
+        publicJwk: VCLPublicJwk,
+        remoteCryptoServicesToken: VCLToken?,
+        completionBlock: @escaping (VCLResult<Bool>) -> Void
+    ) {
+        completionBlock(result)
+    }
+}
+
+private struct BaselineNetworkError: Error, CustomStringConvertible {
+    let message: String
+    var description: String { message }
+}
+
+private final class BaselineHttpRouter: NetworkService {
+    private let verifiedProfilePayload: String
+    private let verifiedProfileStatusCode: Int
+    private let verifiedProfileContentType: String?
+    private let requestPayload: String
+    private let requestStatusCode: Int
+    private let requestContentType: String?
+    private let requestFailure: Error?
+    private let didDocumentPayload: String
+    private let didDocumentStatusCode: Int
+    private let didDocumentContentType: String?
+    private let lock = NSLock()
+    private var endpoints: [String] = []
+    
+    var requestedEndpoints: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return endpoints
+    }
+    
+    init(
+        verifiedProfilePayload: String = VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1,
+        verifiedProfileStatusCode: Int = 200,
+        verifiedProfileContentType: String? = Request.ContentType.ApplicationJson.rawValue,
+        requestPayload: String = CredentialManifestMocks.CredentialManifest1,
+        requestStatusCode: Int = 200,
+        requestContentType: String? = Request.ContentType.ApplicationJson.rawValue,
+        requestFailure: Error? = nil,
+        didDocumentPayload: String = DidDocumentMocks.DidDocumentMockStr,
+        didDocumentStatusCode: Int = 200,
+        didDocumentContentType: String? = Request.ContentType.ApplicationJson.rawValue
+    ) {
+        self.verifiedProfilePayload = verifiedProfilePayload
+        self.verifiedProfileStatusCode = verifiedProfileStatusCode
+        self.verifiedProfileContentType = verifiedProfileContentType
+        self.requestPayload = requestPayload
+        self.requestStatusCode = requestStatusCode
+        self.requestContentType = requestContentType
+        self.requestFailure = requestFailure
+        self.didDocumentPayload = didDocumentPayload
+        self.didDocumentStatusCode = didDocumentStatusCode
+        self.didDocumentContentType = didDocumentContentType
+    }
+    
+    func copy(
+        verifiedProfilePayload: String? = nil,
+        verifiedProfileStatusCode: Int? = nil,
+        verifiedProfileContentType: String? = nil,
+        requestPayload: String? = nil,
+        requestStatusCode: Int? = nil,
+        requestContentType: String? = nil,
+        requestFailure: Error? = nil,
+        didDocumentPayload: String? = nil,
+        didDocumentStatusCode: Int? = nil,
+        didDocumentContentType: String? = nil
+    ) -> BaselineHttpRouter {
+        BaselineHttpRouter(
+            verifiedProfilePayload: verifiedProfilePayload ?? self.verifiedProfilePayload,
+            verifiedProfileStatusCode: verifiedProfileStatusCode ?? self.verifiedProfileStatusCode,
+            verifiedProfileContentType: verifiedProfileContentType ?? self.verifiedProfileContentType,
+            requestPayload: requestPayload ?? self.requestPayload,
+            requestStatusCode: requestStatusCode ?? self.requestStatusCode,
+            requestContentType: requestContentType ?? self.requestContentType,
+            requestFailure: requestFailure ?? self.requestFailure,
+            didDocumentPayload: didDocumentPayload ?? self.didDocumentPayload,
+            didDocumentStatusCode: didDocumentStatusCode ?? self.didDocumentStatusCode,
+            didDocumentContentType: didDocumentContentType ?? self.didDocumentContentType
+        )
+    }
+    
+    func sendRequest(
+        endpoint: String,
+        body: String?,
+        contentType: Request.ContentType,
+        method: Request.HttpMethod,
+        headers: Array<(String, String)>?,
+        cachePolicy: NSURLRequest.CachePolicy,
+        completionBlock: @escaping (VCLResult<Response>) -> Void
+    ) {
+        append(endpoint)
+        if isSdkRequestEndpoint(endpoint) {
+            if let requestFailure = requestFailure {
+                completionBlock(.failure(VCLError(
+                    error: requestFailure,
+                    statusCode: VCLStatusCode.NetworkError.rawValue
+                )))
+                return
+            }
+            if endpoint.hasPrefix("not-a-url") || endpoint.hasPrefix("ftp://") {
+                completionBlock(.failure(VCLError(
+                    error: URLError(.unsupportedURL),
+                    statusCode: VCLStatusCode.NetworkError.rawValue
+                )))
+                return
+            }
+        }
+        
+        let route = route(for: endpoint)
+        if (200...299).contains(route.statusCode) {
+            completionBlock(.success(Response(payload: route.payload.toData(), code: route.statusCode)))
+        } else {
+            completionBlock(.failure(createError(
+                from: route.payload,
+                contentType: route.contentType,
+                statusCode: route.statusCode
+            )))
+        }
+    }
+    
+    private func append(_ endpoint: String) {
+        lock.lock()
+        endpoints.append(endpoint)
+        lock.unlock()
+    }
+    
+    private func route(for endpoint: String) -> Route {
+        if endpoint.contains("/reference/countries") {
+            return Route(200, Request.ContentType.ApplicationJson.rawValue, CountriesMocks.CountriesJson)
+        }
+        if endpoint.contains("/api/v0.6/credential-types") {
+            return Route(200, Request.ContentType.ApplicationJson.rawValue, CredentialTypesMocks.CredentialTypesJson)
+        }
+        if endpoint.contains("/schemas/") {
+            return Route(200, Request.ContentType.ApplicationJson.rawValue, CredentialTypeSchemaMocks.CredentialTypeSchemaJson)
+        }
+        if endpoint.contains("/verified-profile") {
+            return Route(verifiedProfileStatusCode, verifiedProfileContentType, verifiedProfilePayload)
+        }
+        if endpoint.contains("/resolve-did/") {
+            return Route(didDocumentStatusCode, didDocumentContentType, didDocumentPayload)
+        }
+        if isSdkRequestEndpoint(endpoint) {
+            return Route(requestStatusCode, requestContentType, requestPayload)
+        }
+        return Route(500, "text/plain", "Unhandled HTTP endpoint in baseline test: \(endpoint)")
+    }
+    
+    private func isSdkRequestEndpoint(_ endpoint: String) -> Bool {
+        endpoint.contains("get-credential-manifest") ||
+            endpoint.contains("get-presentation-request") ||
+            endpoint.hasPrefix("not-a-url") ||
+            endpoint.hasPrefix("ftp://")
+    }
+    
+    private func createError(from errorPayload: String, contentType: String?, statusCode: Int) -> VCLError {
+        if isJsonContentType(contentType) {
+            return VCLError(
+                error: VCLError(payload: errorPayload),
+                statusCode: statusCode
+            )
+        }
+        
+        return VCLError(
+            message: errorPayload.isEmpty ? nil : errorPayload,
+            statusCode: statusCode
+        )
+    }
+    
+    private func isJsonContentType(_ contentType: String?) -> Bool {
+        guard let contentType = contentType?.lowercased() else {
+            return false
+        }
+        return contentType.contains("application/json") || contentType.contains("+json")
+    }
+}
+
+private struct Route {
+    let statusCode: Int
+    let contentType: String?
+    let payload: String
+    
+    init(_ statusCode: Int, _ contentType: String?, _ payload: String) {
+        self.statusCode = statusCode
+        self.contentType = contentType
+        self.payload = payload
+    }
+}

--- a/VCL/VCLTests/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.swift
+++ b/VCL/VCLTests/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.swift
@@ -250,7 +250,7 @@ final class ErrorTaxonomyBackwardCompatibilityBaselineTest: XCTestCase {
             
             XCTAssertEqual(error.errorCode, VCLErrorCode.SdkError.rawValue)
             XCTAssertTrue(
-                error.error?.contains("public jwk not found for kid") == true,
+                error.message?.contains("public jwk not found for kid") == true,
                 "error: \(error.error ?? "nil"), message: \(error.message ?? "nil")"
             )
         }

--- a/VCL/VCLTests/backwardscompatibility/README.md
+++ b/VCL/VCLTests/backwardscompatibility/README.md
@@ -10,4 +10,3 @@ This directory contains tests that lock in current Swift SDK error propagation b
 - Plain-text HTTP error responses preserve `message` and `statusCode`, but `payload` remains `nil`. Android preserves the same plain text in `payload` as well.
 - Malformed or disallowed `request_uri` values surface as `NSURLErrorDomain Code=-1002` in Swift. Android exposes the corresponding Java URL error text.
 - Non-JSON DID document responses fail while parsing, for example `Failed to parse not json`. The Android-modeled behavior continues to request validation and reports missing public JWK material.
-- Missing DID verification material stores `public jwk not found for kid...` in `VCLError.error`, not `VCLError.message`.

--- a/VCL/VCLTests/backwardscompatibility/README.md
+++ b/VCL/VCLTests/backwardscompatibility/README.md
@@ -8,7 +8,7 @@ This directory contains tests that lock in current Swift SDK error propagation b
 
 - Undecodable query parameters are accepted by `VCLDeepLink` and fail later at the SDK entrypoint with an SDK error. Android rejects these during deep link construction.
 - Plain-text HTTP error responses preserve `message` and `statusCode`, but `payload` remains `nil`. Android preserves the same plain text in `payload` as well.
-- Presentation missing-endpoint failures currently report `credentialManifestDescriptor.endpoint = null`. Android reports a presentation-specific endpoint-null message.
+- Presentation missing-endpoint failures in the current Swift implementation are emitted by `PresentationRequestRepositoryImpl` as `credentialManifestDescriptor.endpoint = null`. Android PR #195's baseline expects `presentationRequestDescriptor.endpoint = null` for the same presentation entrypoint scenario.
 - Malformed or disallowed `request_uri` values surface as `NSURLErrorDomain Code=-1002` in Swift. Android exposes the corresponding Java URL error text.
 - Non-JSON DID document responses fail while parsing, for example `Failed to parse not json`. The Android-modeled behavior continues to request validation and reports missing public JWK material.
 - Missing DID verification material stores `public jwk not found for kid...` in `VCLError.error`, not `VCLError.message`.

--- a/VCL/VCLTests/backwardscompatibility/README.md
+++ b/VCL/VCLTests/backwardscompatibility/README.md
@@ -1,0 +1,14 @@
+# Backwards Compatibility Baselines
+
+This directory contains tests that lock in current Swift SDK error propagation behavior for compatibility checks.
+
+`ErrorTaxonomyBackwardCompatibilityBaselineTest` is modeled on `velocitycareerlabs/WalletAndroid#195`, but it intentionally asserts Swift SDK behavior where Swift currently differs from Android.
+
+## Differences from Android
+
+- Undecodable query parameters are accepted by `VCLDeepLink` and fail later at the SDK entrypoint with an SDK error. Android rejects these during deep link construction.
+- Plain-text HTTP error responses preserve `message` and `statusCode`, but `payload` remains `nil`. Android preserves the same plain text in `payload` as well.
+- Presentation missing-endpoint failures currently report `credentialManifestDescriptor.endpoint = null`. Android reports a presentation-specific endpoint-null message.
+- Malformed or disallowed `request_uri` values surface as `NSURLErrorDomain Code=-1002` in Swift. Android exposes the corresponding Java URL error text.
+- Non-JSON DID document responses fail while parsing, for example `Failed to parse not json`. The Android-modeled behavior continues to request validation and reports missing public JWK material.
+- Missing DID verification material stores `public jwk not found for kid...` in `VCLError.error`, not `VCLError.message`.

--- a/VCL/VCLTests/backwardscompatibility/README.md
+++ b/VCL/VCLTests/backwardscompatibility/README.md
@@ -8,7 +8,6 @@ This directory contains tests that lock in current Swift SDK error propagation b
 
 - Undecodable query parameters are accepted by `VCLDeepLink` and fail later at the SDK entrypoint with an SDK error. Android rejects these during deep link construction.
 - Plain-text HTTP error responses preserve `message` and `statusCode`, but `payload` remains `nil`. Android preserves the same plain text in `payload` as well.
-- Presentation missing-endpoint failures in the current Swift implementation are emitted by `PresentationRequestRepositoryImpl` as `credentialManifestDescriptor.endpoint = null`. Android PR #195's baseline expects `presentationRequestDescriptor.endpoint = null` for the same presentation entrypoint scenario.
 - Malformed or disallowed `request_uri` values surface as `NSURLErrorDomain Code=-1002` in Swift. Android exposes the corresponding Java URL error text.
 - Non-JSON DID document responses fail while parsing, for example `Failed to parse not json`. The Android-modeled behavior continues to request validation and reports missing public JWK material.
 - Missing DID verification material stores `public jwk not found for kid...` in `VCLError.error`, not `VCLError.message`.


### PR DESCRIPTION
## Summary
- add Swift backwards compatibility baseline tests for SDK error propagation modeled on WalletAndroid#195
- add internal network service injection so the tests can run deterministically without live network calls
- document current Swift/Android error propagation differences beside the baseline tests

## Validation
- git diff --check
- xcodebuild test -project VCL/VCL.xcodeproj -scheme VCL -destination 'id=F475CFF6-3E2E-4765-A817-61E48DD4E23E' -only-testing:VCLTests/ErrorTaxonomyBackwardCompatibilityBaselineTest -derivedDataPath /tmp/WalletIOS-3143-DerivedData