### PR TITLE
[codex] Fix iOS RC SDK publish

### DIFF
--- a/.github/releases/v2.10.0.md
+++ b/.github/releases/v2.10.0.md
@@ -7,4 +7,4 @@
 - move taxonomy coverage into integration tests with contract and backward-compatibility baselines
 
 ## Backward incompatibilities
-- Malformed JWTs now fail through the strict decode path instead of lenient `VCLJwt(encodedJwt:)` parsing.
+- Malformed JWTs now fail during strict decode with `JWT must contain header, payload, and signature`. Previously, `VCLJwt(encodedJwt:)` accepted malformed values with nil decoded fields, so issuing and presentation request flows could continue until they failed later during DID resolution with an empty `iss`, or during public-JWK lookup with an empty `kid`.

--- a/.github/releases/v2.10.0.md
+++ b/.github/releases/v2.10.0.md
@@ -1,0 +1,10 @@
+## Changes
+
+### [#180](https://github.com/velocitycareerlabs/WalletIOS/pull/180) Implement SDK error taxonomy
+- add the Swift SDK error taxonomy contract and taxonomy diagnostics on `VCLError`
+- add taxonomy and legacy compatibility modes for SDK initialization
+- align request validation, DID resolution, registration, request authorization, and malformed JWT handling with the Android implementation
+- move taxonomy coverage into integration tests with contract and backward-compatibility baselines
+
+## Backward incompatibilities
+- Malformed JWTs now fail through the strict decode path instead of lenient `VCLJwt(encodedJwt:)` parsing.

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -53,7 +53,7 @@ jobs:
       - set-environment
     runs-on: macos-15
     env:
-      XC_VERSION: "16.3"
+      XC_VERSION: "26.4"
       # Recomends to use separated PAT token to access to another repos
       PAT_TOKEN: ${{ secrets.VCL_RW_ACCESS_TOKEN }}
       RC_SUFFIX: 'rc'
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v4
       # Select latest Xcode
       - name: Select latest Xcode
-        run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app"
+        run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app || sudo xcode-select -s /Applications/Xcode_16.4.app"
       # Extract branch name
       - name: Extract branch name
         shell: bash
@@ -83,8 +83,7 @@ jobs:
         run: echo "FRAMEWORK_VERSION=$(cat VCL.xcodeproj/project.pbxproj | grep PRODUCT_BUNDLE_IDENTIFIER -B 1 | grep MARKETING_VERSION | cut -d'=' -f2 | uniq | sed -e 's/^[ \t]*//;s/;//')${{ env.RELEASE_TAG }}" >> "$GITHUB_ENV"
         working-directory: VCL
         env:
-          # RELEASE_TAG: ${{ env.GLOBAL_ENV != 'prod' && format('{0}{1}', '-', env.RC_SUFFIX ) || '' }}
-          RELEASE_TAG: ${{ '' }}
+          RELEASE_TAG: ${{ env.GLOBAL_ENV != 'prod' && format('{0}{1}', '-', env.RC_SUFFIX ) || '' }}
       # Clone Additional repos
       - name: Clone Additional repos
         run: |

--- a/VCL/VCL.xcodeproj/project.pbxproj
+++ b/VCL/VCL.xcodeproj/project.pbxproj
@@ -2044,7 +2044,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 176;
+				CURRENT_PROJECT_VERSION = 177;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 7DDDGP43MJ;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2057,7 +2057,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.9.3;
+				MARKETING_VERSION = 2.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2074,7 +2074,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 176;
+				CURRENT_PROJECT_VERSION = 177;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 7DDDGP43MJ;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2087,7 +2087,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.9.3;
+				MARKETING_VERSION = 2.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- Update the SDK publish job to select the same current Xcode fallback used by tests.
- Restore RC suffix publishing so release-candidate artifacts publish as `2.10.0-rc` instead of colliding with a prod version.
- Bump the VCL SDK metadata to `2.10.0` / build `177` and add `v2.10.0` release notes for the taxonomy release.

## Root cause

The failing RC publish run selected Xcode 16.3 on the current `macos-15-arm64` runner image. That image reported the iOS 18.4 SDK but did not have the matching device platform available for `generic/platform=iOS`, so `xcodebuild archive` failed before publishing.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-sdk.yml")'`
- `sh -n VCL/scripts/build_xcframework.sh`
- `xcodebuild test -project VCL.xcodeproj -scheme VCL -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17'`
- `scripts/build_xcframework.sh`

Note: the first local `scripts/build_xcframework.sh` attempt failed because an existing local `VCL/build` directory was not marked as Xcode-created. After marking that local build directory, the script completed successfully. CI uses a fresh checkout and should not hit that local cleanup condition.
