### PR TITLE
[codex] Support numbered iOS RC publishes

### DIFF
--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -15,6 +15,10 @@ on:
           - dev
           - rc
           - prod
+      rc_number:
+        description: Positive RC counter used only when environment is rc, for example 1 publishes 2.10.0-rc.1
+        required: false
+        type: string
 env:
   GLOBAL_ENV: ${{ github.event_name == 'push' && format('{0}', 'dev') || inputs.environment }}
 
@@ -72,7 +76,6 @@ jobs:
       XC_VERSION: "26.4"
       # Recomends to use separated PAT token to access to another repos
       PAT_TOKEN: ${{ secrets.VCL_RW_ACCESS_TOKEN }}
-      RC_SUFFIX: 'rc'
       GLOBAL_ENV: ${{ needs.set-environment.outputs.GLOBAL_ENV }}
     steps:
       # Git clone repository
@@ -85,6 +88,29 @@ jobs:
       - name: Extract branch name
         shell: bash
         run: echo "BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}" | sed 's/\//_/g')" >> "$GITHUB_ENV"
+      # Get Version
+      - name: Get Version
+        shell: bash
+        run: |
+          base_framework_version=$(awk -F'= ' '/MARKETING_VERSION/ { gsub(/;/, "", $2); gsub(/[[:space:]]/, "", $2); print $2 }' VCL.xcodeproj/project.pbxproj | uniq | tail -n 1)
+          framework_version="$base_framework_version"
+
+          if [ "$GLOBAL_ENV" = "rc" ]; then
+            if ! [[ "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+              echo "RC publishes require workflow input rc_number as a positive integer."
+              exit 1
+            fi
+            framework_version="${base_framework_version}-rc.${RC_NUMBER}"
+          fi
+
+          {
+            echo "BASE_FRAMEWORK_VERSION=${base_framework_version}"
+            echo "FRAMEWORK_VERSION=${framework_version}"
+            echo "RELEASE_VERSION=v${framework_version}"
+          } >> "$GITHUB_ENV"
+        working-directory: VCL
+        env:
+          RC_NUMBER: ${{ github.event.inputs.rc_number }}
       # VCL build
       - name: VCL build
         run: scripts/build_xcframework.sh
@@ -94,17 +120,28 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-      # Get Version
-      - name: Get Version
-        run: echo "FRAMEWORK_VERSION=$(cat VCL.xcodeproj/project.pbxproj | grep PRODUCT_BUNDLE_IDENTIFIER -B 1 | grep MARKETING_VERSION | cut -d'=' -f2 | uniq | sed -e 's/^[ \t]*//;s/;//')${{ env.RELEASE_TAG }}" >> "$GITHUB_ENV"
-        working-directory: VCL
-        env:
-          RELEASE_TAG: ${{ env.GLOBAL_ENV != 'prod' && format('{0}{1}', '-', env.RC_SUFFIX ) || '' }}
       # Clone Additional repos
       - name: Clone Additional repos
         run: |
           git clone "https://x-access-token:${PAT_TOKEN}@github.com/${{ github.repository_owner }}/Specs.git"
           git clone "https://x-access-token:${PAT_TOKEN}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
+      - name: Validate publish version is new
+        shell: bash
+        run: |
+          if [ -d "Specs/VCL/${FRAMEWORK_VERSION}" ]; then
+            echo "Specs already contains VCL/${FRAMEWORK_VERSION}."
+            exit 1
+          fi
+
+          if git -C VCL-Swift ls-remote --exit-code --tags origin "refs/tags/${FRAMEWORK_VERSION}" >/dev/null 2>&1; then
+            echo "VCL-Swift tag ${FRAMEWORK_VERSION} already exists."
+            exit 1
+          fi
+
+          if [ "$GLOBAL_ENV" = "prod" ] && git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "WalletIOS tag ${RELEASE_VERSION} already exists."
+            exit 1
+          fi
       # Publish to Specs
       - name: Publish to Specs
         run: |

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -92,7 +92,15 @@ jobs:
       - name: Get Version
         shell: bash
         run: |
-          base_framework_version=$(awk -F'= ' '/MARKETING_VERSION/ { gsub(/;/, "", $2); gsub(/[[:space:]]/, "", $2); print $2 }' VCL.xcodeproj/project.pbxproj | uniq | tail -n 1)
+          base_framework_version=$(
+            xcodebuild -project VCL.xcodeproj -scheme VCL -configuration Release -destination generic/platform=iOS -showBuildSettings |
+              awk -F'= ' '/^[[:space:]]*MARKETING_VERSION = / { gsub(/[[:space:]]/, "", $2); print $2; exit }'
+          )
+
+          if [ -z "$base_framework_version" ]; then
+            echo "Unable to determine VCL MARKETING_VERSION."
+            exit 1
+          fi
 
           if [ "$GLOBAL_ENV" = "rc" ]; then
             if ! [[ "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
@@ -111,7 +119,7 @@ jobs:
           } >> "$GITHUB_ENV"
         working-directory: VCL
         env:
-          RC_NUMBER: ${{ github.event.inputs.rc_number }}
+          RC_NUMBER: ${{ inputs.rc_number }}
       # VCL build
       - name: VCL build
         run: scripts/build_xcframework.sh

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           read -r runtime device_type < <(
-            ruby -rjson -e 'runtime = JSON.parse(IO.popen(["xcrun", "simctl", "list", "runtimes", "-j"], &:read))["runtimes"].select { |r| r["isAvailable"] && r["identifier"].include?("iOS") }.max_by { |r| Gem::Version.new(r["version"]) }; device = runtime&.dig("supportedDeviceTypes")&.find { |d| d["productFamily"] == "iPhone" }; puts [runtime&.dig("identifier"), device&.dig("identifier")].compact.join(" ")'
+            ruby -rjson -e 'sdk = Gem::Version.new(IO.popen(["xcrun", "--sdk", "iphonesimulator", "--show-sdk-version"], &:read).strip); runtime = JSON.parse(IO.popen(["xcrun", "simctl", "list", "runtimes", "-j"], &:read))["runtimes"].select { |r| r["isAvailable"] && r["identifier"].include?("iOS") && Gem::Version.new(r["version"]) <= sdk }.max_by { |r| Gem::Version.new(r["version"]) }; device = runtime&.dig("supportedDeviceTypes")&.find { |d| d["productFamily"] == "iPhone" }; puts [runtime&.dig("identifier"), device&.dig("identifier")].compact.join(" ")'
           )
 
           if [ -z "$device_type" ] || [ -z "$runtime" ]; then
@@ -93,7 +93,6 @@ jobs:
         shell: bash
         run: |
           base_framework_version=$(awk -F'= ' '/MARKETING_VERSION/ { gsub(/;/, "", $2); gsub(/[[:space:]]/, "", $2); print $2 }' VCL.xcodeproj/project.pbxproj | uniq | tail -n 1)
-          framework_version="$base_framework_version"
 
           if [ "$GLOBAL_ENV" = "rc" ]; then
             if ! [[ "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
@@ -101,6 +100,8 @@ jobs:
               exit 1
             fi
             framework_version="${base_framework_version}-rc.${RC_NUMBER}"
+          else
+            framework_version="$base_framework_version"
           fi
 
           {

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -95,13 +95,25 @@ jobs:
       - name: Get Version
         shell: bash
         run: |
-          base_framework_version=$(
-            xcodebuild -project VCL.xcodeproj -scheme VCL -configuration Release -destination generic/platform=iOS -showBuildSettings |
-              awk -F'= ' '/^[[:space:]]*MARKETING_VERSION = / { gsub(/[[:space:]]/, "", $2); print $2; exit }'
-          )
+          base_versions=$(awk '
+            /MARKETING_VERSION =/ {
+              version = $3
+              sub(/;$/, "", version)
+            }
+            /PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;/ {
+              print version
+            }
+          ' VCL.xcodeproj/project.pbxproj | sort -u)
+          base_version_count=$(printf '%s\n' "$base_versions" | sed '/^$/d' | wc -l | tr -d ' ')
 
-          if [ -z "$base_framework_version" ]; then
-            echo "Unable to determine VCL MARKETING_VERSION."
+          if [ "$base_version_count" != "1" ]; then
+            echo "Expected exactly one SDK MARKETING_VERSION for io.velocitycareerlabs.VCL, found: ${base_versions}"
+            exit 1
+          fi
+
+          base_framework_version=$(printf '%s\n' "$base_versions" | sed '/^$/d')
+          if [[ ! "$base_framework_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "SDK MARKETING_VERSION must be a semver base version like 2.10.0. Found: ${base_framework_version}"
             exit 1
           fi
 
@@ -142,20 +154,39 @@ jobs:
         run: |
           set -euo pipefail
 
+          check_remote_tag_absent() {
+            local repo_dir="$1"
+            local tag_name="$2"
+            local label="$3"
+            local output
+            local status
+
+            set +e
+            output=$(git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${tag_name}" 2>&1)
+            status=$?
+            set -e
+
+            if [ "$status" -eq 0 ]; then
+              echo "${label} tag ${tag_name} already exists."
+              exit 1
+            fi
+
+            if [ "$status" -eq 2 ]; then
+              return 0
+            fi
+
+            echo "Unable to check ${label} tag ${tag_name}:"
+            echo "$output"
+            exit "$status"
+          }
+
           if [ -d "Specs/VCL/${FRAMEWORK_VERSION}" ]; then
             echo "Specs already contains VCL/${FRAMEWORK_VERSION}."
             exit 1
           fi
 
-          if git -C VCL-Swift ls-remote --exit-code --tags origin "refs/tags/${FRAMEWORK_VERSION}" >/dev/null 2>&1; then
-            echo "VCL-Swift tag ${FRAMEWORK_VERSION} already exists."
-            exit 1
-          fi
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
-            echo "WalletIOS tag ${RELEASE_VERSION} already exists."
-            exit 1
-          fi
+          check_remote_tag_absent VCL-Swift "${FRAMEWORK_VERSION}" "VCL-Swift"
+          check_remote_tag_absent . "${RELEASE_VERSION}" "WalletIOS"
       # Publish to Specs
       - name: Publish to Specs
         run: |

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -214,11 +214,9 @@ jobs:
 
            if [ "${GLOBAL_ENV}" = "prod" ]; then
              echo "${PAT_TOKEN}" | gh auth login --with-token
-             gh release create "${FRAMEWORK_VERSION}" --title "VCL-${FRAMEWORK_VERSION}" "${RELEASE_ARG}"
+             gh release create "${FRAMEWORK_VERSION}" --title "VCL-${FRAMEWORK_VERSION}" --latest
            fi
         working-directory: VCL-Swift
-        env:
-          RELEASE_ARG: ${{ env.GLOBAL_ENV != 'prod' && format('{0}', '--prerelease' ) || format('{0}', '--latest') }}
       - name: Tag and release WalletIOS source
         shell: bash
         run: |

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -81,6 +81,9 @@ jobs:
       # Git clone repository
       - name: Git clone repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ env.PAT_TOKEN }}
       # Select latest Xcode
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app || sudo xcode-select -s /Applications/Xcode_16.4.app"
@@ -137,6 +140,8 @@ jobs:
       - name: Validate publish version is new
         shell: bash
         run: |
+          set -euo pipefail
+
           if [ -d "Specs/VCL/${FRAMEWORK_VERSION}" ]; then
             echo "Specs already contains VCL/${FRAMEWORK_VERSION}."
             exit 1
@@ -147,28 +152,54 @@ jobs:
             exit 1
           fi
 
-          if [ "$GLOBAL_ENV" = "prod" ] && git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
             echo "WalletIOS tag ${RELEASE_VERSION} already exists."
             exit 1
           fi
       # Publish to Specs
       - name: Publish to Specs
         run: |
-          cp -r VCL/0.6.0 VCL/${{ env.FRAMEWORK_VERSION }}
-          sed -i '' 's/0\.6\.0/${{ env.FRAMEWORK_VERSION }}/g' VCL/${{ env.FRAMEWORK_VERSION }}/VCL.podspec
-          git add VCL/${{ env.FRAMEWORK_VERSION }} && git commit -am "sdk ${{ env.FRAMEWORK_VERSION }}" && git push
+          set -euo pipefail
+
+          cp -r VCL/0.6.0 "VCL/${FRAMEWORK_VERSION}"
+          sed -i '' "s/0\.6\.0/${FRAMEWORK_VERSION}/g" "VCL/${FRAMEWORK_VERSION}/VCL.podspec"
+          git add "VCL/${FRAMEWORK_VERSION}"
+          git commit -m "sdk ${FRAMEWORK_VERSION}"
+          git push
         env:
           GITHUB_TOKEN: ${{ env.PAT_TOKEN }}
         working-directory: Specs
       # Publish to VCL-Swift
       - name: Publish to VCL-Swift
         run: |
+           set -euo pipefail
+
            cp -r ../VCL/build/VCL.xcframework Frameworks/
-           git add Frameworks/ && git commit -am "sdk ${{ env.FRAMEWORK_VERSION }}" && git push
-           git tag ${{ env.FRAMEWORK_VERSION }}
-           git push origin ${{ env.FRAMEWORK_VERSION }}
-           echo ${{ env.PAT_TOKEN }} | gh auth login --with-token
-           gh release create ${{ env.FRAMEWORK_VERSION }} --title "VCL-${{ env.FRAMEWORK_VERSION }}" ${{ env.RELEASE_ARG }}
+           git add Frameworks/
+           git commit -am "sdk ${FRAMEWORK_VERSION}"
+           git push
+           git tag "${FRAMEWORK_VERSION}"
+           git push origin "${FRAMEWORK_VERSION}"
+
+           if [ "${GLOBAL_ENV}" = "prod" ]; then
+             echo "${PAT_TOKEN}" | gh auth login --with-token
+             gh release create "${FRAMEWORK_VERSION}" --title "VCL-${FRAMEWORK_VERSION}" "${RELEASE_ARG}"
+           fi
         working-directory: VCL-Swift
         env:
           RELEASE_ARG: ${{ env.GLOBAL_ENV != 'prod' && format('{0}', '--prerelease' ) || format('{0}', '--latest') }}
+      - name: Tag and release WalletIOS source
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git tag "${RELEASE_VERSION}" "${GITHUB_SHA}"
+          git push origin "${RELEASE_VERSION}"
+
+          if [ "${GLOBAL_ENV}" = "prod" ]; then
+            echo "${PAT_TOKEN}" | gh auth login --with-token
+            gh release create "${RELEASE_VERSION}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${RELEASE_VERSION}" \
+              --latest
+          fi

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -95,15 +95,16 @@ jobs:
       - name: Get Version
         shell: bash
         run: |
-          base_versions=$(awk '
-            /MARKETING_VERSION =/ {
-              version = $3
-              sub(/;$/, "", version)
-            }
-            /PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;/ {
-              print version
-            }
-          ' VCL.xcodeproj/project.pbxproj | sort -u)
+          set -euo pipefail
+
+          base_versions=$(
+            xcodebuild -project VCL.xcodeproj -scheme VCL -configuration Release -destination generic/platform=iOS -showBuildSettings |
+              awk '/^[[:space:]]*MARKETING_VERSION = / {
+                gsub(/[[:space:]]/, "", $3)
+                print $3
+              }' |
+              sort -u
+          )
           base_version_count=$(printf '%s\n' "$base_versions" | sed '/^$/d' | wc -l | tr -d ' ')
 
           if [ "$base_version_count" != "1" ]; then
@@ -207,7 +208,7 @@ jobs:
 
            cp -r ../VCL/build/VCL.xcframework Frameworks/
            git add Frameworks/
-           git commit -am "sdk ${FRAMEWORK_VERSION}"
+           git commit -m "sdk ${FRAMEWORK_VERSION}"
            git push
            git tag "${FRAMEWORK_VERSION}"
            git push origin "${FRAMEWORK_VERSION}"

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash
         run: |
           read -r runtime device_type < <(
-            ruby -rjson -e 'runtime = JSON.parse(IO.popen(["xcrun", "simctl", "list", "runtimes", "-j"], &:read))["runtimes"].select { |r| r["isAvailable"] && r["identifier"].include?("iOS") }.max_by { |r| Gem::Version.new(r["version"]) }; device = runtime&.dig("supportedDeviceTypes")&.find { |d| d["productFamily"] == "iPhone" }; puts [runtime&.dig("identifier"), device&.dig("identifier")].compact.join(" ")'
+            ruby -rjson -e 'sdk = Gem::Version.new(IO.popen(["xcrun", "--sdk", "iphonesimulator", "--show-sdk-version"], &:read).strip); runtime = JSON.parse(IO.popen(["xcrun", "simctl", "list", "runtimes", "-j"], &:read))["runtimes"].select { |r| r["isAvailable"] && r["identifier"].include?("iOS") && Gem::Version.new(r["version"]) <= sdk }.max_by { |r| Gem::Version.new(r["version"]) }; device = runtime&.dig("supportedDeviceTypes")&.find { |d| d["productFamily"] == "iPhone" }; puts [runtime&.dig("identifier"), device&.dig("identifier")].compact.join(" ")'
           )
 
           if [ -z "$device_type" ] || [ -z "$runtime" ]; then


### PR DESCRIPTION
## Summary

- Add an explicit `rc_number` workflow input for RC publishes.
- Derive RC publish versions as `<MARKETING_VERSION>-rc.<rc_number>`, e.g. `2.10.0-rc.1`, without changing project metadata per RC.
- Validate duplicate Specs paths, VCL-Swift tags, and WalletIOS source tags before publishing artifacts.
- Publish RCs as tags only: `2.10.0-rc.1` in VCL-Swift and `v2.10.0-rc.1` in WalletIOS.
- Keep GitHub releases for non-RC prod publishes, including normal patch, minor, and major versions.

## Scope

Implements manual numbered RC publishing. This does not add auto-increment behavior and does not modify Android.

## Validation

- `actionlint .github/workflows/ios-sdk.yml .github/workflows/tests-ios-sdk.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-sdk.yml"); YAML.load_file(".github/workflows/tests-ios-sdk.yml")'`\n- `git diff --check`\n- Local dry-run confirmed `2.10.0-rc.1` maps to WalletIOS tag `v2.10.0-rc.1`, while prod maps to `v2.10.0` with release creation.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added release-candidate publishing support by introducing an optional RC number input, with stricter version parsing/validation and consistent framework/publish version outputs.
  * Improved iOS SDK release automation to avoid duplicate publishing and apply consistent tagging/release metadata, creating releases only for production builds.
  * Updated iOS simulator preparation to select an available simulator runtime compatible with (≤) the installed Xcode SDK version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->