### PR TITLE
fix(ci): support existing publish token credentials

### DIFF
--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -104,8 +104,16 @@ jobs:
       - name: Clone Additional repos
         shell: bash
         run: |
-          git clone "https://${PAT_TOKEN}@github.com/${{ github.repository_owner }}/Specs.git"
-          git clone "https://${PAT_TOKEN}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
+          credential="${PAT_TOKEN}"
+          if [[ "${credential}" != *:* ]]; then
+            credential="x-access-token:${PAT_TOKEN}"
+          fi
+          auth_header="AUTHORIZATION: basic $(printf '%s' "${credential}" | base64 | tr -d '\n')"
+
+          git -c "http.https://github.com/.extraheader=${auth_header}" clone "https://github.com/${{ github.repository_owner }}/Specs.git"
+          git -c "http.https://github.com/.extraheader=${auth_header}" clone "https://github.com/${{ github.repository_owner }}/VCL-Swift.git"
+          git -C Specs config --local "http.https://github.com/.extraheader" "${auth_header}"
+          git -C VCL-Swift config --local "http.https://github.com/.extraheader" "${auth_header}"
       # Publish to Specs
       - name: Publish to Specs
         run: |

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Clone Additional repos
         shell: bash
         run: |
-          git clone "https://${PAT_TOKEN}@github.com/${{ github.repository_owner }}/Specs.git"
-          git clone "https://${PAT_TOKEN}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
+          git clone "https://${{ env.PAT_TOKEN }}@github.com/${{ github.repository_owner }}/Specs.git"
+          git clone "https://${{ env.PAT_TOKEN }}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
       # Publish to Specs
       - name: Publish to Specs
         run: |

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -102,9 +102,15 @@ jobs:
           RELEASE_TAG: ${{ env.GLOBAL_ENV != 'prod' && format('{0}{1}', '-', env.RC_SUFFIX ) || '' }}
       # Clone Additional repos
       - name: Clone Additional repos
+        shell: bash
         run: |
-          git clone "https://x-access-token:${PAT_TOKEN}@github.com/${{ github.repository_owner }}/Specs.git"
-          git clone "https://x-access-token:${PAT_TOKEN}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
+          git_auth="${PAT_TOKEN}"
+          if [[ "${git_auth}" != *:* ]]; then
+            git_auth="${GITHUB_ACTOR}:${PAT_TOKEN}"
+          fi
+
+          git clone "https://${git_auth}@github.com/${{ github.repository_owner }}/Specs.git"
+          git clone "https://${git_auth}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
       # Publish to Specs
       - name: Publish to Specs
         run: |

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -104,13 +104,8 @@ jobs:
       - name: Clone Additional repos
         shell: bash
         run: |
-          git_auth="${PAT_TOKEN}"
-          if [[ "${git_auth}" != *:* ]]; then
-            git_auth="${GITHUB_ACTOR}:${PAT_TOKEN}"
-          fi
-
-          git clone "https://${git_auth}@github.com/${{ github.repository_owner }}/Specs.git"
-          git clone "https://${git_auth}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
+          git clone "https://${PAT_TOKEN}@github.com/${{ github.repository_owner }}/Specs.git"
+          git clone "https://${PAT_TOKEN}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
       # Publish to Specs
       - name: Publish to Specs
         run: |

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -104,16 +104,8 @@ jobs:
       - name: Clone Additional repos
         shell: bash
         run: |
-          credential="${PAT_TOKEN}"
-          if [[ "${credential}" != *:* ]]; then
-            credential="x-access-token:${PAT_TOKEN}"
-          fi
-          auth_header="AUTHORIZATION: basic $(printf '%s' "${credential}" | base64 | tr -d '\n')"
-
-          git -c "http.https://github.com/.extraheader=${auth_header}" clone "https://github.com/${{ github.repository_owner }}/Specs.git"
-          git -c "http.https://github.com/.extraheader=${auth_header}" clone "https://github.com/${{ github.repository_owner }}/VCL-Swift.git"
-          git -C Specs config --local "http.https://github.com/.extraheader" "${auth_header}"
-          git -C VCL-Swift config --local "http.https://github.com/.extraheader" "${auth_header}"
+          git clone "https://${PAT_TOKEN}@github.com/${{ github.repository_owner }}/Specs.git"
+          git clone "https://${PAT_TOKEN}@github.com/${{ github.repository_owner }}/VCL-Swift.git"
       # Publish to Specs
       - name: Publish to Specs
         run: |


### PR DESCRIPTION
## Summary
- allow the SDK publish workflow to clone publish repos with either a raw PAT or an existing user:token credential
- keep the authenticated remote URL usable for subsequent git push operations

## Verification
- actionlint .github/workflows/ios-sdk.yml

Refs: https://github.com/velocitycareerlabs/WalletIOS/actions/runs/26734611749/job/78785433132