### PR TITLE
[codex] Revive release policy

### DIFF
--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -132,10 +132,39 @@ jobs:
             echo "BASE_FRAMEWORK_VERSION=${base_framework_version}"
             echo "FRAMEWORK_VERSION=${framework_version}"
             echo "RELEASE_VERSION=v${framework_version}"
+            echo "RELEASE_NOTES_FILE=${GITHUB_WORKSPACE}/.github/releases/v${base_framework_version}.md"
           } >> "$GITHUB_ENV"
         working-directory: VCL
         env:
           RC_NUMBER: ${{ inputs.rc_number }}
+      - name: Validate prod release context
+        if: env.GLOBAL_ENV == 'prod'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          major_minor=$(printf '%s' "${BASE_FRAMEWORK_VERSION}" | cut -d. -f1,2)
+          patch_version=$(printf '%s' "${BASE_FRAMEWORK_VERSION}" | cut -d. -f3)
+          expected_release_branch="release/v${major_minor}"
+
+          if [ "${GITHUB_REF_NAME}" != "main" ] && [ "${GITHUB_REF_NAME}" != "${expected_release_branch}" ]; then
+            echo "Prod builds for ${BASE_FRAMEWORK_VERSION} may only run from main or ${expected_release_branch}."
+            exit 1
+          fi
+
+          if [ "$patch_version" != "0" ] && [ "${GITHUB_REF_NAME}" != "${expected_release_branch}" ]; then
+            echo "Patch release ${BASE_FRAMEWORK_VERSION} must run from ${expected_release_branch}."
+            exit 1
+          fi
+
+          if [ ! -f "${RELEASE_NOTES_FILE}" ]; then
+            echo "Missing release notes file: ${RELEASE_NOTES_FILE}"
+            exit 1
+          fi
+
+          grep -q '^## Changes$' "${RELEASE_NOTES_FILE}" || { echo "Release notes must include a '## Changes' section."; exit 1; }
+          grep -q '^## Backward incompatibilities$' "${RELEASE_NOTES_FILE}" || { echo "Release notes must include a '## Backward incompatibilities' section."; exit 1; }
+          grep -Eq '^### \[#[0-9]+\]\([^)]+\)( .+)?$' "${RELEASE_NOTES_FILE}" || { echo "Release notes must include at least one release entry heading in the form '### [#PR](URL) ...'."; exit 1; }
       # VCL build
       - name: VCL build
         run: scripts/build_xcframework.sh
@@ -214,8 +243,8 @@ jobs:
            git push origin "${FRAMEWORK_VERSION}"
 
            if [ "${GLOBAL_ENV}" = "prod" ]; then
-             echo "${PAT_TOKEN}" | gh auth login --with-token
-             gh release create "${FRAMEWORK_VERSION}" --title "VCL-${FRAMEWORK_VERSION}" --latest
+            echo "${PAT_TOKEN}" | gh auth login --with-token
+            gh release create "${FRAMEWORK_VERSION}" --title "VCL-${FRAMEWORK_VERSION}" --latest
            fi
         working-directory: VCL-Swift
       - name: Tag and release WalletIOS source
@@ -231,5 +260,6 @@ jobs:
             gh release create "${RELEASE_VERSION}" \
               --repo "${GITHUB_REPOSITORY}" \
               --title "${RELEASE_VERSION}" \
+              --notes-file "${RELEASE_NOTES_FILE}" \
               --latest
           fi

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -27,29 +27,37 @@ jobs:
             git fetch origin "${base_sha}" --depth=1
           fi
 
-          version_diff=$(git diff --unified=0 "${base_sha}...HEAD" -- VCL/VCL.xcodeproj/project.pbxproj)
-          if ! printf '%s\n' "$version_diff" | grep -q '^[+-].*MARKETING_VERSION = '; then
+          extract_sdk_version() {
+            local ref="$1"
+            git show "${ref}:VCL/VCL.xcodeproj/project.pbxproj" | awk '
+              /MARKETING_VERSION =/ {
+                version = $3
+                sub(/;$/, "", version)
+              }
+              /PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;/ {
+                print version
+              }
+            ' | sed '/^$/d' | sort -u
+          }
+
+          base_versions=$(extract_sdk_version "${base_sha}")
+          head_versions=$(extract_sdk_version "HEAD")
+          base_version_count=$(printf '%s\n' "$base_versions" | sed '/^$/d' | wc -l | tr -d ' ')
+          head_version_count=$(printf '%s\n' "$head_versions" | sed '/^$/d' | wc -l | tr -d ' ')
+
+          if [ "$base_version_count" != "1" ] || [ "$head_version_count" != "1" ]; then
+            echo "Expected exactly one SDK MARKETING_VERSION for io.velocitycareerlabs.VCL in base and head."
+            echo "Base versions: ${base_versions:-<none>}"
+            echo "Head versions: ${head_versions:-<none>}"
+            exit 1
+          fi
+
+          if [ "$base_versions" = "$head_versions" ]; then
             echo "No SDK version change detected; skipping release notes validation."
             exit 0
           fi
 
-          framework_versions=$(awk '
-            /MARKETING_VERSION =/ {
-              version = $3
-              sub(/;$/, "", version)
-            }
-            /PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;/ {
-              print version
-            }
-          ' VCL/VCL.xcodeproj/project.pbxproj | sort -u)
-          framework_version_count=$(printf '%s\n' "$framework_versions" | sed '/^$/d' | wc -l | tr -d ' ')
-
-          if [ "$framework_version_count" != "1" ]; then
-            echo "Expected exactly one SDK MARKETING_VERSION for io.velocitycareerlabs.VCL, found: ${framework_versions}"
-            exit 1
-          fi
-
-          framework_version=$(printf '%s\n' "$framework_versions" | sed '/^$/d')
+          framework_version="$head_versions"
           release_version="v${framework_version}"
           release_notes_file=".github/releases/${release_version}.md"
           major_minor=$(printf '%s' "$framework_version" | cut -d. -f1,2)

--- a/.github/workflows/tests-ios-sdk.yml
+++ b/.github/workflows/tests-ios-sdk.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - release/**
+      - release/v*
 jobs:
   tests-ios-sdk:
     runs-on: macos-15
@@ -14,6 +14,70 @@ jobs:
       # Git clone repository
       - name: Git clone repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate release notes for publish PRs
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          base_sha="${BASE_SHA}"
+          if ! git rev-parse --verify "${base_sha}^{commit}" >/dev/null 2>&1; then
+            git fetch origin "${base_sha}" --depth=1
+          fi
+
+          version_diff=$(git diff --unified=0 "${base_sha}...HEAD" -- VCL/VCL.xcodeproj/project.pbxproj)
+          if ! printf '%s\n' "$version_diff" | grep -q '^[+-].*MARKETING_VERSION = '; then
+            echo "No SDK version change detected; skipping release notes validation."
+            exit 0
+          fi
+
+          framework_versions=$(awk '
+            /MARKETING_VERSION =/ {
+              version = $3
+              sub(/;$/, "", version)
+            }
+            /PRODUCT_BUNDLE_IDENTIFIER = io.velocitycareerlabs.VCL;/ {
+              print version
+            }
+          ' VCL/VCL.xcodeproj/project.pbxproj | sort -u)
+          framework_version_count=$(printf '%s\n' "$framework_versions" | sed '/^$/d' | wc -l | tr -d ' ')
+
+          if [ "$framework_version_count" != "1" ]; then
+            echo "Expected exactly one SDK MARKETING_VERSION for io.velocitycareerlabs.VCL, found: ${framework_versions}"
+            exit 1
+          fi
+
+          framework_version=$(printf '%s\n' "$framework_versions" | sed '/^$/d')
+          release_version="v${framework_version}"
+          release_notes_file=".github/releases/${release_version}.md"
+          major_minor=$(printf '%s' "$framework_version" | cut -d. -f1,2)
+          patch_version=$(printf '%s' "$framework_version" | cut -d. -f3)
+
+          if [ ! -f "$release_notes_file" ]; then
+            echo "$release_notes_file must exist for version $release_version."
+            exit 1
+          fi
+
+          if git diff --quiet "${base_sha}...HEAD" -- "$release_notes_file"; then
+            echo "$release_notes_file must be added or updated in the same PR as the version bump."
+            exit 1
+          fi
+
+          grep -q '^## Changes$' "$release_notes_file" || { echo "$release_notes_file is missing a '## Changes' section."; exit 1; }
+          grep -q '^## Backward incompatibilities$' "$release_notes_file" || { echo "$release_notes_file is missing a '## Backward incompatibilities' section."; exit 1; }
+          grep -Eq '^### \[#[0-9]+\]\([^)]+\)( .+)?$' "$release_notes_file" || { echo "$release_notes_file must include at least one release entry heading in the form '### [#PR](URL) ...'."; exit 1; }
+
+          if [[ "$BASE_REF" == release/v* ]] && [ "$BASE_REF" != "release/v${major_minor}" ]; then
+            echo "Version ${framework_version} must target branch release/v${major_minor}, not ${BASE_REF}."
+            exit 1
+          fi
+
+          if [ "$BASE_REF" = "main" ] && [ "$patch_version" != "0" ]; then
+            echo "Patch version ${framework_version} should not be bumped via a PR targeting main."
+            exit 1
+          fi
       # Select latest Xcode
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app || sudo xcode-select -s /Applications/Xcode_16.4.app"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+- If you discover a likely bug, regression, or product gap that is not the central purpose of the current thread, explicitly ask whether I want you to create a GitHub issue for it.
+- Never amend commits unless directed.
+- When creating tests, if the code under test is pure logic, then create unit tests. If the code under test is orchestration, an adapter, or validation logic, then create integration tests from the public-facing endpoint. Check if you are unsure.
+- See [RELEASING.md](RELEASING.md) for the WalletIOS release branching, tagging, and GitHub release-notes policy.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,38 @@
+# Releasing WalletIOS
+
+## Branch Policy
+
+- `main` is for the next minor line under active development.
+- Each stabilizing minor line gets a long-lived branch named `release/vX.Y`.
+- Patch releases for that line are cut from the matching `release/vX.Y` branch.
+- Do not create one branch per patch version.
+
+Example:
+- Cut `release/v2.9` from `main` when `2.9.0` enters stabilization.
+- Bump `main` forward to `2.10.0` so next-minor work continues there.
+- Ship `v2.9.0`, `v2.9.1`, and `v2.9.2` from the release commits on `release/v2.9`.
+
+## Release Notes Policy
+
+- Every version bump PR must add or update `.github/releases/vX.Y.Z.md`.
+- Release notes must include:
+  - `## Changes`
+  - at least one `### [#PR](...) ...` entry
+  - `## Backward incompatibilities`
+- The release notes file should describe the shipped SDK changes in the same style used for GitHub Releases.
+
+## Release PR Policy
+
+- Tags must point to the release commit that was actually shipped.
+- Prod releases must only be run from:
+  - `release/vX.Y` for patch releases where `Z > 0`
+  - `main` or `release/vX.Y` for initial `vX.Y.0` releases
+
+## Recommended Flow
+
+1. Cut `release/vX.Y` from `main`.
+2. Bump `main` to the next minor version.
+3. Prepare a release PR into `release/vX.Y` with the version bump and `.github/releases/vX.Y.Z.md`.
+4. Merge that PR and use the resulting release commit as the source of truth for the shipped tag.
+5. Run the prod release workflow from the release commit.
+6. Cherry-pick or forward-port fixes between `release/vX.Y` and `main` as needed.


### PR DESCRIPTION
## What changed

- Added `RELEASING.md` to document the release branch, tag, and release-notes policy.
- Added root `AGENTS.md` guidance with the current repo instructions and a pointer to the release policy.
- Restored PR-time validation that SDK version bumps include the matching `.github/releases/vX.Y.Z.md` file.
- Updated the publish workflow to derive the SDK version from the `io.velocitycareerlabs.VCL` target, validate prod release context, and create prod GitHub Releases from WalletIOS source tags.
- Preserved the later simulator and workflow fixes that landed after PR #177, and kept RC prerelease publishing behavior intact.

## Why

PR #177 was still open and unmerged, but it had become stale and conflicted with current `main`. This revives the still-useful release policy work on top of the current workflow state.

## Validation

- `actionlint`
- Ruby YAML parse for `.github/workflows/tests-ios-sdk.yml` and `.github/workflows/ios-sdk.yml`
- `git diff --check`
- Local check that `.github/releases/v2.10.0.md` matches the stricter release-entry heading pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved iOS SDK release automation with stronger validation of release-notes content and formatting before creating production releases.
  * Ensured GitHub release bodies are consistently generated from the computed release-notes markdown file.

* **Tests**
  * Restricted iOS SDK workflow runs to pull requests targeting `release/v*` branches and added checks that required release-notes sections and entries are present.

* **Documentation**
  * Added `AGENTS.md` with contribution and testing guidance.
  * Added `RELEASING.md` with WalletIOS release and release-notes requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->