### PR TITLE
[codex] fix ios sdk release promotion

### DIFF
--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -241,8 +241,9 @@ jobs:
         run: |
            set -euo pipefail
 
+           rm -rf Frameworks/VCL.xcframework
            cp -r ../VCL/build/VCL.xcframework Frameworks/
-           git add Frameworks/
+           git add -A Frameworks/VCL.xcframework
            if git diff --cached --quiet; then
             echo "VCL-Swift Frameworks already match ${FRAMEWORK_VERSION}; tagging current HEAD."
            else

--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -202,8 +202,7 @@ jobs:
           }
 
           if [ -d "Specs/VCL/${FRAMEWORK_VERSION}" ]; then
-            echo "Specs already contains VCL/${FRAMEWORK_VERSION}."
-            exit 1
+            echo "Specs already contains VCL/${FRAMEWORK_VERSION}; publish step will verify it matches the generated podspec."
           fi
 
           check_remote_tag_absent VCL-Swift "${FRAMEWORK_VERSION}" "VCL-Swift"
@@ -213,8 +212,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          cp -r VCL/0.6.0 "VCL/${FRAMEWORK_VERSION}"
-          sed -i '' "s/0\.6\.0/${FRAMEWORK_VERSION}/g" "VCL/${FRAMEWORK_VERSION}/VCL.podspec"
+          generated_spec_dir=$(mktemp -d)
+          trap 'rm -rf "${generated_spec_dir}"' EXIT
+
+          cp -r VCL/0.6.0 "${generated_spec_dir}/${FRAMEWORK_VERSION}"
+          sed -i '' "s/0\.6\.0/${FRAMEWORK_VERSION}/g" "${generated_spec_dir}/${FRAMEWORK_VERSION}/VCL.podspec"
+
+          if [ -d "VCL/${FRAMEWORK_VERSION}" ]; then
+            if diff -qr "VCL/${FRAMEWORK_VERSION}" "${generated_spec_dir}/${FRAMEWORK_VERSION}" >/dev/null; then
+              echo "Specs already contains matching VCL/${FRAMEWORK_VERSION}; skipping Specs commit."
+              exit 0
+            fi
+
+            echo "Specs already contains VCL/${FRAMEWORK_VERSION}, but it differs from the generated podspec."
+            diff -ru "VCL/${FRAMEWORK_VERSION}" "${generated_spec_dir}/${FRAMEWORK_VERSION}" || true
+            exit 1
+          fi
+
+          mv "${generated_spec_dir}/${FRAMEWORK_VERSION}" "VCL/${FRAMEWORK_VERSION}"
           git add "VCL/${FRAMEWORK_VERSION}"
           git commit -m "sdk ${FRAMEWORK_VERSION}"
           git push
@@ -228,8 +243,12 @@ jobs:
 
            cp -r ../VCL/build/VCL.xcframework Frameworks/
            git add Frameworks/
-           git commit -m "sdk ${FRAMEWORK_VERSION}"
-           git push
+           if git diff --cached --quiet; then
+            echo "VCL-Swift Frameworks already match ${FRAMEWORK_VERSION}; tagging current HEAD."
+           else
+            git commit -m "sdk ${FRAMEWORK_VERSION}"
+            git push
+           fi
            git tag "${FRAMEWORK_VERSION}"
            git push origin "${FRAMEWORK_VERSION}"
 


### PR DESCRIPTION
## Summary

- Allow the iOS SDK publish workflow to continue when the Specs repo already contains a matching generated podspec.
- Allow final releases to tag/release the existing `VCL-Swift` commit when the built framework matches the previously published RC artifact.

## Root cause

The `2.10.0` publish failed after pushing `Specs/VCL/2.10.0` because `Publish to VCL-Swift` required `git commit` to create a new commit before tagging. When the final framework matched the RC framework already on `VCL-Swift/main`, `git commit` exited with `nothing to commit, working tree clean`, so the workflow never created the `VCL-Swift` `2.10.0` tag/release or the WalletIOS `v2.10.0` tag/release.

## Validation

- `actionlint .github/workflows/ios-sdk.yml`
- YAML parse with Ruby
- `bash -n` for embedded workflow scripts
- `shellcheck` on the patched publish blocks
- Confirmed the existing `Specs/VCL/2.10.0/VCL.podspec` matches the generated podspec template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the iOS SDK publishing workflow to be more deterministic and avoid redundant commits. The release process now handles existing versions by verifying consistency rather than overwriting, and only creates commits/pushes when there are actual staged changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->