### PR TITLE
[codex] fix ios source release auth

### DIFF
--- a/.github/workflows/ios-sdk.yml
+++ b/.github/workflows/ios-sdk.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ env.PAT_TOKEN }}
+          token: ${{ github.token }}
       # Select latest Xcode
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_${{ env.XC_VERSION }}.app || sudo xcode-select -s /Applications/Xcode_16.4.app"
@@ -175,12 +175,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          check_remote_tag_absent() {
+          check_remote_tag_absent_or_at_ref() {
             local repo_dir="$1"
             local tag_name="$2"
             local label="$3"
+            local expected_ref="$4"
+            local expected_sha
             local output
+            local remote_sha
             local status
+
+            expected_sha=$(git -C "$repo_dir" rev-parse "$expected_ref")
 
             set +e
             output=$(git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${tag_name}" 2>&1)
@@ -188,7 +193,13 @@ jobs:
             set -e
 
             if [ "$status" -eq 0 ]; then
-              echo "${label} tag ${tag_name} already exists."
+              remote_sha=$(printf '%s\n' "$output" | awk 'END {print $1}')
+              if [ "$remote_sha" = "$expected_sha" ]; then
+                echo "${label} tag ${tag_name} already exists at the expected commit; publish step will verify and skip it."
+                return 0
+              fi
+
+              echo "${label} tag ${tag_name} already exists at ${remote_sha}, expected ${expected_sha}."
               exit 1
             fi
 
@@ -205,8 +216,8 @@ jobs:
             echo "Specs already contains VCL/${FRAMEWORK_VERSION}; publish step will verify it matches the generated podspec."
           fi
 
-          check_remote_tag_absent VCL-Swift "${FRAMEWORK_VERSION}" "VCL-Swift"
-          check_remote_tag_absent . "${RELEASE_VERSION}" "WalletIOS"
+          check_remote_tag_absent_or_at_ref VCL-Swift "${FRAMEWORK_VERSION}" "VCL-Swift" HEAD
+          check_remote_tag_absent_or_at_ref . "${RELEASE_VERSION}" "WalletIOS" "${GITHUB_SHA}"
       # Publish to Specs
       - name: Publish to Specs
         run: |
@@ -241,36 +252,66 @@ jobs:
         run: |
            set -euo pipefail
 
+           tag_exists=false
+           if git ls-remote --exit-code --tags origin "refs/tags/${FRAMEWORK_VERSION}" >/dev/null 2>&1; then
+            tag_exists=true
+           fi
+
            rm -rf Frameworks/VCL.xcframework
            cp -r ../VCL/build/VCL.xcframework Frameworks/
            git add -A Frameworks/VCL.xcframework
            if git diff --cached --quiet; then
             echo "VCL-Swift Frameworks already match ${FRAMEWORK_VERSION}; tagging current HEAD."
+           elif [ "$tag_exists" = "true" ]; then
+            echo "VCL-Swift tag ${FRAMEWORK_VERSION} already exists, but the rebuilt framework differs from the tagged commit."
+            exit 1
            else
             git commit -m "sdk ${FRAMEWORK_VERSION}"
             git push
            fi
-           git tag "${FRAMEWORK_VERSION}"
-           git push origin "${FRAMEWORK_VERSION}"
+
+           if [ "$tag_exists" = "true" ]; then
+            echo "VCL-Swift tag ${FRAMEWORK_VERSION} already exists; skipping tag push."
+           else
+            git tag "${FRAMEWORK_VERSION}"
+            git push origin "${FRAMEWORK_VERSION}"
+           fi
 
            if [ "${GLOBAL_ENV}" = "prod" ]; then
-            echo "${PAT_TOKEN}" | gh auth login --with-token
-            gh release create "${FRAMEWORK_VERSION}" --title "VCL-${FRAMEWORK_VERSION}" --latest
+            if GH_TOKEN="${PAT_TOKEN}" gh release view "${FRAMEWORK_VERSION}" >/dev/null 2>&1; then
+             echo "VCL-Swift release ${FRAMEWORK_VERSION} already exists; skipping release creation."
+            else
+             GH_TOKEN="${PAT_TOKEN}" gh release create "${FRAMEWORK_VERSION}" --title "VCL-${FRAMEWORK_VERSION}" --latest
+            fi
            fi
         working-directory: VCL-Swift
       - name: Tag and release WalletIOS source
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          git tag "${RELEASE_VERSION}" "${GITHUB_SHA}"
-          git push origin "${RELEASE_VERSION}"
+          tag_exists=false
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
+            tag_exists=true
+          fi
+
+          if [ "$tag_exists" = "true" ]; then
+            echo "WalletIOS tag ${RELEASE_VERSION} already exists; skipping tag push."
+          else
+            git tag "${RELEASE_VERSION}" "${GITHUB_SHA}"
+            git push origin "${RELEASE_VERSION}"
+          fi
 
           if [ "${GLOBAL_ENV}" = "prod" ]; then
-            echo "${PAT_TOKEN}" | gh auth login --with-token
-            gh release create "${RELEASE_VERSION}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --title "${RELEASE_VERSION}" \
-              --notes-file "${RELEASE_NOTES_FILE}" \
-              --latest
+            if gh release view "${RELEASE_VERSION}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "WalletIOS release ${RELEASE_VERSION} already exists; skipping release creation."
+            else
+              gh release create "${RELEASE_VERSION}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --title "${RELEASE_VERSION}" \
+                --notes-file "${RELEASE_NOTES_FILE}" \
+                --latest
+            fi
           fi


### PR DESCRIPTION
## Summary

- Use the repository `GITHUB_TOKEN` for the WalletIOS checkout so the workflow can push the WalletIOS source tag.
- Keep `VCL_RW_ACCESS_TOKEN` for cross-repo Specs and VCL-Swift publishing.
- Make the VCL-Swift and WalletIOS tag/release steps idempotent when a rerun follows a partial publish.

## Root cause

Run https://github.com/velocitycareerlabs/WalletIOS/actions/runs/27655852082/job/81790010312 passed the previously fixed Specs and VCL-Swift steps, then failed in `Tag and release WalletIOS source`:

```text
remote: Permission to velocitycareerlabs/WalletIOS.git denied to vclops.
fatal: unable to access 'https://github.com/velocitycareerlabs/WalletIOS/': The requested URL returned error: 403
```

The checkout remote was authenticated with `VCL_RW_ACCESS_TOKEN`, whose `vclops` identity can publish the auxiliary repos but cannot push tags to WalletIOS. After that failed run, `VCL-Swift` now has tag/release `2.10.0`, so the workflow also needs to tolerate that completed part on rerun and continue to the missing WalletIOS source tag/release.

## Validation

- `actionlint .github/workflows/ios-sdk.yml`
- YAML parse with Ruby
- `bash -n` for embedded workflow scripts
- `shellcheck` on the patched publish blocks
- Confirmed `VCL-Swift/main` and tag `2.10.0` point to the same commit
- Confirmed WalletIOS tag `v2.10.0` is still absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced iOS SDK and WalletIOS publishing workflows with improved validation for existing tags and conditional release creation to ensure consistent, idempotent release handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->